### PR TITLE
Accept relayed DHCPv4 on FreeBSD with trusted-relay security model (#57)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.swo
 .env
+/.worktrees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to rDHCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.12.0] - 2026-04-17
+## [0.12.5] - 2026-04-17
 
 ### Added
 - **DHCPv4 relay agent support on FreeBSD** — a second per-worker receive
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multicast, broadcast, class E, unspecified) before further processing.
 - A per-relay-source rate limiter is applied to relayed traffic in
   addition to the existing per-MAC limiter.
+
+### Changed (post-merge polish)
+- Dedicated `relay_rate_limit_burst` / `relay_rate_limit_pps` (defaults 200 / 100.0) — the previous behavior reused per-MAC defaults which were too restrictive for a relay.
+- Bad-giaddr and untrusted-relay drops now log at `debug!` (they fire before the per-relay rate limiter — counters remain authoritative).
+- Malformed `trusted_relays` entries are now logged as warnings at startup instead of being silently dropped.
 
 ## [0.8.0] - 2026-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to rDHCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-04-17
+
+### Added
+- **DHCPv4 relay agent support on FreeBSD** — a second per-worker receive
+  socket on `0.0.0.0:67` is now opened alongside the existing broadcast
+  socket so requests forwarded from a DHCP relay (`giaddr != 0`) are
+  received and processed. Previously FreeBSD silently dropped these.
+  (Fixes #57.)
+- `[global] accept_relayed = true|false` — global kill-switch for relayed
+  DHCP (default: `true`).
+- `[[subnet]] trusted_relays = ["<ip>", ...]` — per-subnet whitelist of
+  relay agent source IPs (default: empty = accept any relay).
+- Prometheus metrics: `rdhcpd_dhcpv4_relayed_received_total` and
+  `rdhcpd_dhcpv4_relayed_dropped_total{reason="..."}` with reasons
+  `accept_relayed_disabled`, `bad_giaddr`, `untrusted_relay`, `rate_limit`.
+
+### Security
+- `giaddr` is validated against a bogon list (loopback, link-local,
+  multicast, broadcast, class E, unspecified) before further processing.
+- A per-relay-source rate limiter is applied to relayed traffic in
+  addition to the existing per-MAC limiter.
+
 ## [0.8.0] - 2026-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.11.1"
+version = "0.12.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"
@@ -10,6 +10,9 @@ readme = "README.md"
 keywords = ["dhcp", "dhcpv6", "networking", "server", "high-availability"]
 categories = ["network-programming", "command-line-utilities"]
 
+[features]
+test-helpers = []
+
 [lib]
 name = "rdhcpd"
 path = "src/lib.rs"
@@ -17,6 +20,10 @@ path = "src/lib.rs"
 [[bin]]
 name = "rdhcpd"
 path = "src/main.rs"
+
+[[test]]
+name = "dhcpv4_relay_gates"
+required-features = ["test-helpers"]
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.11.9"
+version = "0.12.0"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,12 +43,16 @@ rDHCP is a network infrastructure service that typically runs as root. Key secur
   information) is **not** used for client identity.
 - A separate rate limiter is applied per UDP source IP on relayed traffic so
   a single misbehaving relay cannot exhaust the global per-MAC budget.
+- A misbehaving trusted relay can cycle the per-MAC rate-limiter bucket
+  table (bounded at 100,000 entries) by forwarding packets with many
+  fabricated MACs. The per-relay-source rate limit caps throughput but not
+  uniqueness — restrict `trusted_relays` to known-good relay agents.
 
 ### Input Validation
 - All DHCP packet fields are bounds-checked before access
 - Option lengths are validated against RFC limits (255 bytes for DHCPv4, 65535 for DHCPv6)
 - Magic cookie verification prevents processing non-DHCP traffic
-- Hop count validation (>32 rejected) prevents relay loops
+- Hop count validation prevents relay loops (DHCPv4: >16 rejected per RFC 1542; DHCPv6: >32 rejected per RFC 8415)
 
 ### Denial of Service
 - Per-client rate limiting prevents DHCP starvation attacks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,20 @@ rDHCP is a network infrastructure service that typically runs as root. Key secur
 - DHCP operates on privileged ports (67, 547) requiring root or `CAP_NET_BIND_SERVICE`
 - HA peer communication uses mutual TLS (mTLS) with certificate verification
 - The management API should be bound to localhost or a management network, not public interfaces
+- DHCP relay agent forwarding (`giaddr != 0`) is accepted by default. On
+  FreeBSD the server listens on both `255.255.255.255:67` (directly-connected
+  broadcasts) and `0.0.0.0:67` (relayed unicast) so relayed requests are
+  received. To disable relay acceptance entirely set `accept_relayed = false`
+  in `[global]`. To restrict which relay agents may forward to a subnet, set
+  `trusted_relays = ["<relay-ip>", ...]` on each `[[subnet]]` — packets from
+  any other source are dropped silently and counted under
+  `rdhcpd_dhcpv4_relayed_dropped_total{reason="untrusted_relay"}`.
+- Relay input is additionally validated: `giaddr` must not be a bogon
+  (loopback/link-local/multicast/broadcast/reserved) and must fall within a
+  configured subnet, otherwise the packet is dropped. Option 82 (relay agent
+  information) is **not** used for client identity.
+- A separate rate limiter is applied per UDP source IP on relayed traffic so
+  a single misbehaving relay cannot exhaust the global per-MAC budget.
 
 ### Input Validation
 - All DHCP packet fields are bounds-checked before access

--- a/example-config.toml
+++ b/example-config.toml
@@ -20,6 +20,8 @@ global_rate_limit_pps = 0.0       # global rate limit, 0 = disabled (packets/sec
 rogue_threshold = 50              # requests per window before rogue alert
 rogue_window_secs = 60            # sliding window for rogue detection
 pool_high_water = 0.9             # warn when pool utilization exceeds this (0.0-1.0)
+accept_relayed = true             # accept DHCP packets forwarded by a relay agent
+                                  # (giaddr != 0). Set false to disable relay support entirely.
 
 # -----------------------------------------------------------------------------
 # REST Management API
@@ -78,6 +80,10 @@ ip_probe = false                  # probe IP before offering (duplicate detectio
 # ip_probe_timeout_ms = 500       # probe timeout in ms
 # mac_allow = ["aa:bb:cc:dd:ee:f1", "aa:bb:cc:dd:ee:f2"]  # whitelist (empty = allow all)
 # mac_deny = ["00:11:22:33:44:55"]                          # blacklist (checked first)
+
+# --- DHCP Relay ---
+# trusted_relays = ["10.0.1.2"]    # restrict relayed packets to these source IPs
+                                  # empty = accept from any relay (if accept_relayed=true)
 
 # --- Static Reservations ---
 [[subnet.reservation]]

--- a/example-config.toml
+++ b/example-config.toml
@@ -22,6 +22,8 @@ rogue_window_secs = 60            # sliding window for rogue detection
 pool_high_water = 0.9             # warn when pool utilization exceeds this (0.0-1.0)
 accept_relayed = true             # accept DHCP packets forwarded by a relay agent
                                   # (giaddr != 0). Set false to disable relay support entirely.
+relay_rate_limit_burst = 200      # per-relay-source burst (higher than per-MAC — relays aggregate many clients)
+relay_rate_limit_pps = 100.0      # per-relay-source sustained rate (packets/sec)
 
 # -----------------------------------------------------------------------------
 # REST Management API

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -102,5 +102,62 @@ pub async fn metrics_handler<H: HaBackend>(
         if ha_status.healthy { 1 } else { 0 }
     ));
 
+    // DHCPv4 relay counters
+    use std::sync::atomic::Ordering;
+    let s = &state.dhcpv4_stats;
+
+    output.push_str("# HELP rdhcpd_dhcpv4_relayed_received_total DHCPv4 packets received with giaddr != 0\n");
+    output.push_str("# TYPE rdhcpd_dhcpv4_relayed_received_total counter\n");
+    output.push_str(&format!(
+        "rdhcpd_dhcpv4_relayed_received_total {}\n",
+        s.relayed_received.load(Ordering::Relaxed)
+    ));
+
+    output.push_str("# HELP rdhcpd_dhcpv4_relayed_dropped_total DHCPv4 relayed packets dropped, by reason\n");
+    output.push_str("# TYPE rdhcpd_dhcpv4_relayed_dropped_total counter\n");
+    output.push_str(&format!(
+        "rdhcpd_dhcpv4_relayed_dropped_total{{reason=\"accept_relayed_disabled\"}} {}\n",
+        s.relayed_dropped_disabled.load(Ordering::Relaxed)
+    ));
+    output.push_str(&format!(
+        "rdhcpd_dhcpv4_relayed_dropped_total{{reason=\"bad_giaddr\"}} {}\n",
+        s.relayed_dropped_bad_giaddr.load(Ordering::Relaxed)
+    ));
+    output.push_str(&format!(
+        "rdhcpd_dhcpv4_relayed_dropped_total{{reason=\"untrusted_relay\"}} {}\n",
+        s.relayed_dropped_untrusted_relay.load(Ordering::Relaxed)
+    ));
+    output.push_str(&format!(
+        "rdhcpd_dhcpv4_relayed_dropped_total{{reason=\"rate_limit\"}} {}\n",
+        s.relayed_dropped_rate_limit.load(Ordering::Relaxed)
+    ));
+
     ([(header::CONTENT_TYPE, "text/plain; version=0.0.4")], output)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dhcpv4::stats::DhcpV4Stats;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn metrics_strings_are_emitted_for_relay_counters() {
+        let s = Arc::new(DhcpV4Stats::new());
+        s.relayed_received.fetch_add(7, Ordering::Relaxed);
+        s.relayed_dropped_untrusted_relay.fetch_add(2, Ordering::Relaxed);
+
+        let mut output = String::new();
+        output.push_str(&format!(
+            "rdhcpd_dhcpv4_relayed_received_total {}\n",
+            s.relayed_received.load(Ordering::Relaxed)
+        ));
+        output.push_str(&format!(
+            "rdhcpd_dhcpv4_relayed_dropped_total{{reason=\"untrusted_relay\"}} {}\n",
+            s.relayed_dropped_untrusted_relay.load(Ordering::Relaxed)
+        ));
+
+        assert!(output.contains("rdhcpd_dhcpv4_relayed_received_total 7"));
+        assert!(output.contains("rdhcpd_dhcpv4_relayed_dropped_total{reason=\"untrusted_relay\"} 2"));
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -33,6 +33,8 @@ pub struct ApiState<H: HaBackend> {
     pub wal: Arc<Wal>,
     /// Optional API key for authenticating management requests
     pub api_key: Option<String>,
+    /// DHCPv4 relay observability counters
+    pub dhcpv4_stats: Arc<crate::dhcpv4::stats::DhcpV4Stats>,
 }
 
 /// Authentication middleware — checks X-API-Key header against configured key.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -56,6 +56,14 @@ pub struct GlobalConfig {
     /// regardless of per-subnet trusted_relays configuration.
     #[serde(default = "default_accept_relayed")]
     pub accept_relayed: bool,
+    /// Per-relay-agent-source rate limit: maximum burst size (packets).
+    /// Higher than the per-MAC default because a single relay aggregates
+    /// many clients. Applied only to packets with `giaddr != 0`.
+    #[serde(default = "default_relay_rate_limit_burst")]
+    pub relay_rate_limit_burst: u32,
+    /// Per-relay-agent-source rate limit: sustained packets per second.
+    #[serde(default = "default_relay_rate_limit_pps")]
+    pub relay_rate_limit_pps: f64,
 }
 
 /// REST API server configuration.
@@ -354,6 +362,14 @@ fn default_accept_relayed() -> bool {
     true
 }
 
+fn default_relay_rate_limit_burst() -> u32 {
+    200
+}
+
+fn default_relay_rate_limit_pps() -> f64 {
+    100.0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,6 +399,36 @@ mode = "standalone"
 "#;
         let c: Config = toml::from_str(toml).unwrap();
         assert!(!c.global.accept_relayed);
+    }
+
+    #[test]
+    fn relay_rate_limit_defaults_applied_when_omitted() {
+        let toml = r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+"#;
+        let c: Config = toml::from_str(toml).unwrap();
+        assert_eq!(c.global.relay_rate_limit_burst, 200);
+        assert!((c.global.relay_rate_limit_pps - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn relay_rate_limit_explicit_values_parse() {
+        let toml = r#"
+[global]
+lease_db = "/tmp/x"
+relay_rate_limit_burst = 500
+relay_rate_limit_pps = 250.0
+
+[ha]
+mode = "standalone"
+"#;
+        let c: Config = toml::from_str(toml).unwrap();
+        assert_eq!(c.global.relay_rate_limit_burst, 500);
+        assert!((c.global.relay_rate_limit_pps - 250.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -51,6 +51,11 @@ pub struct GlobalConfig {
     /// Pool utilization high-water mark (0.0-1.0) for alerting.
     #[serde(default = "default_pool_high_water")]
     pub pool_high_water: f64,
+    /// Whether to accept DHCP packets with giaddr != 0 (i.e. forwarded by a
+    /// DHCP relay agent). When false, all relayed packets are dropped early
+    /// regardless of per-subnet trusted_relays configuration.
+    #[serde(default = "default_accept_relayed")]
+    pub accept_relayed: bool,
 }
 
 /// REST API server configuration.
@@ -170,6 +175,11 @@ pub struct SubnetConfig {
     /// MAC deny list (these MACs are always rejected).
     #[serde(default)]
     pub mac_deny: Vec<String>,
+    /// Trusted DHCP relay agent source IPs for this subnet. When non-empty,
+    /// relayed packets whose UDP source IP is not on this list are dropped.
+    /// When empty, all relays are accepted (backwards-compatible default).
+    #[serde(default)]
+    pub trusted_relays: Vec<String>,
 
     // Reservations
     /// Static address reservations for specific clients.
@@ -338,4 +348,61 @@ fn default_pool_high_water() -> f64 {
 
 fn default_max_leases_per_mac() -> u32 {
     1
+}
+
+fn default_accept_relayed() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_accept_relayed_defaults_to_true() {
+        let toml = r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+"#;
+        let c: Config = toml::from_str(toml).unwrap();
+        assert!(c.global.accept_relayed);
+    }
+
+    #[test]
+    fn global_accept_relayed_can_be_disabled() {
+        let toml = r#"
+[global]
+lease_db = "/tmp/x"
+accept_relayed = false
+
+[ha]
+mode = "standalone"
+"#;
+        let c: Config = toml::from_str(toml).unwrap();
+        assert!(!c.global.accept_relayed);
+    }
+
+    #[test]
+    fn subnet_trusted_relays_defaults_empty_and_can_be_set() {
+        let toml = r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+
+[[subnet]]
+network = "10.0.1.0/24"
+trusted_relays = ["10.0.1.5", "10.0.1.6"]
+"#;
+        let c: Config = toml::from_str(toml).unwrap();
+        assert!(c.subnet[0].trusted_relays.is_empty());
+        assert_eq!(c.subnet[1].trusted_relays, vec!["10.0.1.5", "10.0.1.6"]);
+    }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -312,7 +312,6 @@ fn subnets_overlap(a_addr: IpAddr, a_prefix: u8, b_addr: IpAddr, b_prefix: u8) -
 /// Return true if the given address is unsuitable as a DHCP relay agent
 /// source (giaddr). Rejects loopback, link-local, multicast, broadcast,
 /// reserved (class E), and the unspecified address.
-#[allow(dead_code)]
 pub fn is_bogon_giaddr(ip: Ipv4Addr) -> bool {
     ip.is_unspecified()
         || ip.is_loopback()

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use tracing::warn;
 
@@ -313,7 +313,7 @@ fn subnets_overlap(a_addr: IpAddr, a_prefix: u8, b_addr: IpAddr, b_prefix: u8) -
 /// source (giaddr). Rejects loopback, link-local, multicast, broadcast,
 /// reserved (class E), and the unspecified address.
 #[allow(dead_code)]
-pub fn is_bogon_giaddr(ip: std::net::Ipv4Addr) -> bool {
+pub fn is_bogon_giaddr(ip: Ipv4Addr) -> bool {
     ip.is_unspecified()
         || ip.is_loopback()
         || ip.is_link_local()

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -308,3 +308,60 @@ fn subnets_overlap(a_addr: IpAddr, a_prefix: u8, b_addr: IpAddr, b_prefix: u8) -
     let b_val = ip_to_u128(&b_addr);
     (a_val >> shift) == (b_val >> shift)
 }
+
+/// Return true if the given address is unsuitable as a DHCP relay agent
+/// source (giaddr). Rejects loopback, link-local, multicast, broadcast,
+/// reserved (class E), and the unspecified address.
+#[allow(dead_code)]
+pub fn is_bogon_giaddr(ip: std::net::Ipv4Addr) -> bool {
+    ip.is_unspecified()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_multicast()
+        || ip.is_broadcast()
+        // Class E reserved (240.0.0.0/4) — is_reserved is unstable, so check manually.
+        || (ip.octets()[0] & 0xF0) == 0xF0
+}
+
+#[cfg(test)]
+mod giaddr_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn loopback_is_bogon() {
+        assert!(is_bogon_giaddr(Ipv4Addr::new(127, 0, 0, 1)));
+    }
+
+    #[test]
+    fn link_local_is_bogon() {
+        assert!(is_bogon_giaddr(Ipv4Addr::new(169, 254, 1, 1)));
+    }
+
+    #[test]
+    fn multicast_is_bogon() {
+        assert!(is_bogon_giaddr(Ipv4Addr::new(224, 0, 0, 1)));
+    }
+
+    #[test]
+    fn broadcast_is_bogon() {
+        assert!(is_bogon_giaddr(Ipv4Addr::BROADCAST));
+    }
+
+    #[test]
+    fn reserved_class_e_is_bogon() {
+        assert!(is_bogon_giaddr(Ipv4Addr::new(240, 0, 0, 1)));
+    }
+
+    #[test]
+    fn unspecified_is_bogon() {
+        assert!(is_bogon_giaddr(Ipv4Addr::UNSPECIFIED));
+    }
+
+    #[test]
+    fn normal_unicast_is_not_bogon() {
+        assert!(!is_bogon_giaddr(Ipv4Addr::new(10, 0, 0, 1)));
+        assert!(!is_bogon_giaddr(Ipv4Addr::new(192, 168, 1, 1)));
+        assert!(!is_bogon_giaddr(Ipv4Addr::new(172, 29, 69, 5)));
+    }
+}

--- a/src/dhcpv4/mod.rs
+++ b/src/dhcpv4/mod.rs
@@ -6,3 +6,5 @@ pub mod options;
 pub mod packet;
 /// DHCPv4 server request handling and response logic.
 pub mod server;
+/// Atomic counters for DHCPv4 relay observability.
+pub mod stats;

--- a/src/dhcpv4/packet.rs
+++ b/src/dhcpv4/packet.rs
@@ -345,6 +345,32 @@ impl DhcpV4Packet {
     }
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
+impl DhcpV4Packet {
+    /// Construct a minimal BOOTREQUEST Discover packet for tests.
+    pub fn new_discover(mac: [u8; 6]) -> Self {
+        let mut chaddr = [0u8; 16];
+        chaddr[..6].copy_from_slice(&mac);
+        Self {
+            op: 1, // BOOTREQUEST
+            htype: 1,
+            hlen: 6,
+            hops: 0,
+            xid: 0x12345678,
+            secs: 0,
+            flags: 0,
+            ciaddr: Ipv4Addr::UNSPECIFIED,
+            yiaddr: Ipv4Addr::UNSPECIFIED,
+            siaddr: Ipv4Addr::UNSPECIFIED,
+            giaddr: Ipv4Addr::UNSPECIFIED,
+            chaddr,
+            sname: [0u8; 64],
+            file: [0u8; 128],
+            options: vec![DhcpOption::MessageType(MessageType::Discover)],
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -39,6 +39,23 @@ pub enum DhcpSender {
 /// Duration to hold an Offer before it expires (seconds)
 const OFFER_HOLD_TIME: u64 = 30;
 
+/// Outcome of the relay-security classification.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RelayDecision {
+    /// Packet is not relayed — skip relay checks.
+    NotRelayed,
+    /// Relayed and accepted.
+    Accept,
+    /// Dropped because `accept_relayed = false`.
+    DroppedDisabled,
+    /// Dropped because giaddr is a bogon or does not match a subnet.
+    DroppedBadGiaddr,
+    /// Dropped because the UDP source IP is not in the subnet's trusted_relays.
+    DroppedUntrustedRelay,
+    /// Dropped by the per-relay-source rate limiter.
+    DroppedRateLimit,
+}
+
 /// Returns true if `source` is an acceptable relay agent for `subnet`.
 /// Empty trusted_relays = accept any source (backwards-compatible default).
 fn relay_source_is_trusted(subnet: &SubnetInfo, source: Ipv4Addr) -> bool {
@@ -174,6 +191,54 @@ impl<H: HaBackend> DhcpV4Server<H> {
         }
     }
 
+    /// Classify a received DHCPv4 packet against the relay security gates.
+    /// Increments the appropriate `stats` counter as a side-effect.
+    pub fn classify_relayed(
+        &self,
+        packet: &DhcpV4Packet,
+        src_addr: SocketAddr,
+    ) -> RelayDecision {
+        if !packet.is_relayed() {
+            return RelayDecision::NotRelayed;
+        }
+        use std::sync::atomic::Ordering;
+        self.stats.relayed_received.fetch_add(1, Ordering::Relaxed);
+
+        if !self.config_accept_relayed {
+            self.stats.relayed_dropped_disabled.fetch_add(1, Ordering::Relaxed);
+            return RelayDecision::DroppedDisabled;
+        }
+        if crate::config::validation::is_bogon_giaddr(packet.giaddr) {
+            self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
+            return RelayDecision::DroppedBadGiaddr;
+        }
+        let relay_subnet = match self.subnets.iter().find(|s| {
+            ip_in_subnet(&IpAddr::V4(packet.giaddr), &IpAddr::V4(s.network_addr), s.prefix_len)
+        }) {
+            Some(s) => s,
+            None => {
+                self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
+                return RelayDecision::DroppedBadGiaddr;
+            }
+        };
+        let source_ip = match src_addr.ip() {
+            IpAddr::V4(v4) => v4,
+            _ => {
+                self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
+                return RelayDecision::DroppedUntrustedRelay;
+            }
+        };
+        if !relay_source_is_trusted(relay_subnet, source_ip) {
+            self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
+            return RelayDecision::DroppedUntrustedRelay;
+        }
+        if !self.relay_rate_limiter.check(&source_ip.octets()) {
+            self.stats.relayed_dropped_rate_limit.fetch_add(1, Ordering::Relaxed);
+            return RelayDecision::DroppedRateLimit;
+        }
+        RelayDecision::Accept
+    }
+
     /// Run the DHCPv4 server loop.
     ///
     /// `recv_socket` receives DHCP requests (may be bound to broadcast addr on FreeBSD).
@@ -219,60 +284,22 @@ impl<H: HaBackend> DhcpV4Server<H> {
                 continue;
             }
 
-            // Relay security gates (issue #57 — RFC 3046 hardening)
-            if packet.is_relayed() {
-                use std::sync::atomic::Ordering;
-                self.stats.relayed_received.fetch_add(1, Ordering::Relaxed);
-
-                // Global kill-switch
-                if !self.config_accept_relayed {
-                    self.stats.relayed_dropped_disabled.fetch_add(1, Ordering::Relaxed);
+            // Relay security gates (issue #57) — see classify_relayed.
+            match self.classify_relayed(&packet, src_addr) {
+                RelayDecision::NotRelayed | RelayDecision::Accept => {}
+                RelayDecision::DroppedDisabled => {
                     debug!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: accept_relayed=false");
                     continue;
                 }
-
-                // Bogon/martian check on giaddr
-                if crate::config::validation::is_bogon_giaddr(packet.giaddr) {
-                    self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
-                    warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: bogon giaddr");
+                RelayDecision::DroppedBadGiaddr => {
+                    warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: bogon or unknown-subnet giaddr");
                     continue;
                 }
-
-                // giaddr MUST match a configured subnet
-                let relay_subnet = self.subnets.iter().find(|s| {
-                    ip_in_subnet(
-                        &IpAddr::V4(packet.giaddr),
-                        &IpAddr::V4(s.network_addr),
-                        s.prefix_len,
-                    )
-                });
-                let relay_subnet = match relay_subnet {
-                    Some(s) => s,
-                    None => {
-                        self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
-                        warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: giaddr does not match any configured subnet");
-                        continue;
-                    }
-                };
-
-                // Trusted-relay source IP check (per-subnet whitelist)
-                let source_ip = match src_addr.ip() {
-                    IpAddr::V4(v4) => v4,
-                    _ => {
-                        self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    }
-                };
-                if !relay_source_is_trusted(relay_subnet, source_ip) {
-                    self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
-                    warn!(src = %src_addr, giaddr = %packet.giaddr, subnet = %relay_subnet.network, "dropping relayed packet: source IP not in trusted_relays");
+                RelayDecision::DroppedUntrustedRelay => {
+                    warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: source IP not in trusted_relays");
                     continue;
                 }
-
-                // Per-relay-source rate limit (additive, in addition to per-MAC)
-                let source_key = source_ip.octets();
-                if !self.relay_rate_limiter.check(&source_key) {
-                    self.stats.relayed_dropped_rate_limit.fetch_add(1, Ordering::Relaxed);
+                RelayDecision::DroppedRateLimit => {
                     debug!(src = %src_addr, "dropping relayed packet: per-relay rate limit");
                     continue;
                 }

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -292,11 +292,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
                     continue;
                 }
                 RelayDecision::DroppedBadGiaddr => {
-                    warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: bogon or unknown-subnet giaddr");
+                    debug!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: bogon or unknown-subnet giaddr");
                     continue;
                 }
                 RelayDecision::DroppedUntrustedRelay => {
-                    warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: source IP not in trusted_relays");
+                    debug!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: source IP not in trusted_relays");
                     continue;
                 }
                 RelayDecision::DroppedRateLimit => {

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -74,6 +74,20 @@ struct SubnetInfo {
     config: Arc<SubnetConfig>,
     /// Per-subnet MAC ACL
     mac_acl: Arc<MacAcl>,
+    /// Pre-parsed trusted relay agent source IPs. Empty = accept any relay.
+    #[allow(dead_code)]
+    trusted_relays: Arc<[Ipv4Addr]>,
+}
+
+impl SubnetInfo {
+    /// Parse the raw trusted_relays strings from a SubnetConfig into Ipv4Addr.
+    /// Invalid entries are silently dropped.
+    fn parse_trusted_relays(cfg: &SubnetConfig) -> Vec<Ipv4Addr> {
+        cfg.trusted_relays
+            .iter()
+            .filter_map(|s| s.parse::<Ipv4Addr>().ok())
+            .collect()
+    }
 }
 
 impl<H: HaBackend> DhcpV4Server<H> {
@@ -117,6 +131,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
                         prefix_len,
                         config: Arc::new(s.clone()),
                         mac_acl,
+                        trusted_relays: Arc::from(SubnetInfo::parse_trusted_relays(s)),
                     })
                 } else {
                     None
@@ -997,5 +1012,53 @@ fn hex_nibble(c: u8) -> Option<u8> {
         b'a'..=b'f' => Some(c - b'a' + 10),
         b'A'..=b'F' => Some(c - b'A' + 10),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod subnet_info_tests {
+    use super::*;
+    use crate::config::SubnetConfig;
+
+    fn make_subnet(network: &str, trusted: Vec<String>) -> SubnetConfig {
+        SubnetConfig {
+            network: network.to_string(),
+            pool_start: None,
+            pool_end: None,
+            lease_time: 3600,
+            max_lease_time: None,
+            renewal_time: None,
+            rebinding_time: None,
+            preferred_time: None,
+            subnet_type: "address".to_string(),
+            delegated_length: None,
+            router: None,
+            dns: vec![],
+            domain: None,
+            ip_probe: false,
+            ip_probe_timeout_ms: None,
+            max_leases_per_mac: 1,
+            mac_allow: vec![],
+            mac_deny: vec![],
+            trusted_relays: trusted,
+            reservation: vec![],
+        }
+    }
+
+    #[test]
+    fn trusted_relays_are_parsed_into_subnet_info() {
+        let cfg = make_subnet(
+            "10.0.0.0/24",
+            vec!["10.0.0.5".to_string(), "invalid".to_string(), "10.0.0.6".to_string()],
+        );
+        let parsed = SubnetInfo::parse_trusted_relays(&cfg);
+        assert_eq!(parsed, vec![Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 6)]);
+    }
+
+    #[test]
+    fn empty_trusted_relays_parses_to_empty_vec() {
+        let cfg = make_subnet("10.0.0.0/24", vec![]);
+        let parsed = SubnetInfo::parse_trusted_relays(&cfg);
+        assert!(parsed.is_empty());
     }
 }

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -39,6 +39,13 @@ pub enum DhcpSender {
 /// Duration to hold an Offer before it expires (seconds)
 const OFFER_HOLD_TIME: u64 = 30;
 
+/// Returns true if `source` is an acceptable relay agent for `subnet`.
+/// Empty trusted_relays = accept any source (backwards-compatible default).
+fn relay_source_is_trusted(subnet: &SubnetInfo, source: Ipv4Addr) -> bool {
+    subnet.trusted_relays.is_empty()
+        || subnet.trusted_relays.iter().any(|ip| *ip == source)
+}
+
 /// Minimum lease time we'll grant (prevents rapid-churn DoS)
 const MIN_LEASE_TIME: u32 = 60;
 
@@ -62,13 +69,13 @@ pub struct DhcpV4Server<H: HaBackend> {
     /// Rogue client detector
     rogue_detector: Arc<RogueDetector>,
     /// Per-relay-source rate limiter (keyed by UDP source IP bytes).
-    #[allow(dead_code)]
     relay_rate_limiter: Arc<RateLimiter>,
     /// Observability counters for relay handling.
-    #[allow(dead_code)]
     stats: Arc<DhcpV4Stats>,
     /// Pool utilization high-water mark for alerting
     pool_high_water: f64,
+    /// Snapshot of `config.global.accept_relayed` for cheap reads.
+    config_accept_relayed: bool,
 }
 
 /// Pre-parsed subnet information for runtime lookups.
@@ -82,7 +89,6 @@ struct SubnetInfo {
     /// Per-subnet MAC ACL
     mac_acl: Arc<MacAcl>,
     /// Pre-parsed trusted relay agent source IPs. Empty = accept any relay.
-    #[allow(dead_code)]
     trusted_relays: Arc<[Ipv4Addr]>,
 }
 
@@ -149,6 +155,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
             .collect();
 
         let pool_high_water = config.global.pool_high_water;
+        let config_accept_relayed = config.global.accept_relayed;
 
         Self {
             lease_store,
@@ -163,6 +170,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
             relay_rate_limiter,
             stats,
             pool_high_water,
+            config_accept_relayed,
         }
     }
 
@@ -209,6 +217,65 @@ impl<H: HaBackend> DhcpV4Server<H> {
                     "dropping packet with excessive hop count"
                 );
                 continue;
+            }
+
+            // Relay security gates (issue #57 — RFC 3046 hardening)
+            if packet.is_relayed() {
+                use std::sync::atomic::Ordering;
+                self.stats.relayed_received.fetch_add(1, Ordering::Relaxed);
+
+                // Global kill-switch
+                if !self.config_accept_relayed {
+                    self.stats.relayed_dropped_disabled.fetch_add(1, Ordering::Relaxed);
+                    debug!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: accept_relayed=false");
+                    continue;
+                }
+
+                // Bogon/martian check on giaddr
+                if crate::config::validation::is_bogon_giaddr(packet.giaddr) {
+                    self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
+                    warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: bogon giaddr");
+                    continue;
+                }
+
+                // giaddr MUST match a configured subnet
+                let relay_subnet = self.subnets.iter().find(|s| {
+                    ip_in_subnet(
+                        &IpAddr::V4(packet.giaddr),
+                        &IpAddr::V4(s.network_addr),
+                        s.prefix_len,
+                    )
+                });
+                let relay_subnet = match relay_subnet {
+                    Some(s) => s,
+                    None => {
+                        self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
+                        warn!(src = %src_addr, giaddr = %packet.giaddr, "dropping relayed packet: giaddr does not match any configured subnet");
+                        continue;
+                    }
+                };
+
+                // Trusted-relay source IP check (per-subnet whitelist)
+                let source_ip = match src_addr.ip() {
+                    IpAddr::V4(v4) => v4,
+                    _ => {
+                        self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                };
+                if !relay_source_is_trusted(relay_subnet, source_ip) {
+                    self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
+                    warn!(src = %src_addr, giaddr = %packet.giaddr, subnet = %relay_subnet.network, "dropping relayed packet: source IP not in trusted_relays");
+                    continue;
+                }
+
+                // Per-relay-source rate limit (additive, in addition to per-MAC)
+                let source_key = source_ip.octets();
+                if !self.relay_rate_limiter.check(&source_key) {
+                    self.stats.relayed_dropped_rate_limit.fetch_add(1, Ordering::Relaxed);
+                    debug!(src = %src_addr, "dropping relayed packet: per-relay rate limit");
+                    continue;
+                }
             }
 
             let msg_type = match packet.message_type() {
@@ -1023,6 +1090,62 @@ fn hex_nibble(c: u8) -> Option<u8> {
         b'a'..=b'f' => Some(c - b'a' + 10),
         b'A'..=b'F' => Some(c - b'A' + 10),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod relay_gate_tests {
+    use super::*;
+    use crate::config::SubnetConfig;
+    use crate::ratelimit::MacAcl;
+
+    fn make_subnet_info(network_str: &str, prefix: u8, trusted: Vec<Ipv4Addr>) -> SubnetInfo {
+        let cfg = SubnetConfig {
+            network: format!("{}/{}", network_str, prefix),
+            pool_start: None,
+            pool_end: None,
+            lease_time: 3600,
+            max_lease_time: None,
+            renewal_time: None,
+            rebinding_time: None,
+            preferred_time: None,
+            subnet_type: "address".to_string(),
+            delegated_length: None,
+            router: None,
+            dns: vec![],
+            domain: None,
+            ip_probe: false,
+            ip_probe_timeout_ms: None,
+            max_leases_per_mac: 1,
+            mac_allow: vec![],
+            mac_deny: vec![],
+            trusted_relays: trusted.iter().map(|ip| ip.to_string()).collect(),
+            reservation: vec![],
+        };
+        SubnetInfo {
+            network: Arc::from(cfg.network.as_str()),
+            network_addr: network_str.parse().unwrap(),
+            prefix_len: prefix,
+            config: Arc::new(cfg),
+            mac_acl: Arc::new(MacAcl::new(vec![], vec![])),
+            trusted_relays: Arc::from(trusted.as_slice()),
+        }
+    }
+
+    #[test]
+    fn empty_trusted_relays_allows_any_source() {
+        let subnet = make_subnet_info("10.0.0.0", 24, vec![]);
+        assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 5)));
+        assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(192, 168, 1, 1)));
+    }
+
+    #[test]
+    fn populated_trusted_relays_enforces_match() {
+        let trusted = vec![Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 6)];
+        let subnet = make_subnet_info("10.0.0.0", 24, trusted);
+        assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 5)));
+        assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 6)));
+        assert!(!relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 7)));
     }
 }
 

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -11,6 +11,7 @@ use super::packet::{DhcpV4Packet, MAX_PACKET_SIZE};
 use crate::allocator::SubnetAllocator;
 use crate::config::validation::{ip_in_subnet, parse_cidr, parse_mac};
 use crate::config::{Config, SubnetConfig};
+use crate::dhcpv4::stats::DhcpV4Stats;
 use crate::ha::HaBackend;
 use crate::lease::store::LeaseStore;
 use crate::lease::types::{Lease, LeaseState};
@@ -60,6 +61,12 @@ pub struct DhcpV4Server<H: HaBackend> {
     global_rate_limiter: Option<Arc<GlobalRateLimiter>>,
     /// Rogue client detector
     rogue_detector: Arc<RogueDetector>,
+    /// Per-relay-source rate limiter (keyed by UDP source IP bytes).
+    #[allow(dead_code)]
+    relay_rate_limiter: Arc<RateLimiter>,
+    /// Observability counters for relay handling.
+    #[allow(dead_code)]
+    stats: Arc<DhcpV4Stats>,
     /// Pool utilization high-water mark for alerting
     pool_high_water: f64,
 }
@@ -102,6 +109,8 @@ impl<H: HaBackend> DhcpV4Server<H> {
         rate_limiter: Arc<RateLimiter>,
         global_rate_limiter: Option<Arc<GlobalRateLimiter>>,
         rogue_detector: Arc<RogueDetector>,
+        relay_rate_limiter: Arc<RateLimiter>,
+        stats: Arc<DhcpV4Stats>,
     ) -> Self {
         let subnets: Vec<SubnetInfo> = config
             .subnet
@@ -151,6 +160,8 @@ impl<H: HaBackend> DhcpV4Server<H> {
             rate_limiter,
             global_rate_limiter,
             rogue_detector,
+            relay_rate_limiter,
+            stats,
             pool_high_water,
         }
     }

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -111,12 +111,21 @@ struct SubnetInfo {
 
 impl SubnetInfo {
     /// Parse the raw trusted_relays strings from a SubnetConfig into Ipv4Addr.
-    /// Invalid entries are silently dropped.
+    /// Invalid entries emit a warning and are dropped (never panics).
     fn parse_trusted_relays(cfg: &SubnetConfig) -> Vec<Ipv4Addr> {
-        cfg.trusted_relays
-            .iter()
-            .filter_map(|s| s.parse::<Ipv4Addr>().ok())
-            .collect()
+        let mut out = Vec::with_capacity(cfg.trusted_relays.len());
+        for s in &cfg.trusted_relays {
+            match s.parse::<Ipv4Addr>() {
+                Ok(ip) => out.push(ip),
+                Err(e) => warn!(
+                    subnet = %cfg.network,
+                    entry = %s,
+                    error = %e,
+                    "ignoring malformed trusted_relays entry"
+                ),
+            }
+        }
+        out
     }
 }
 
@@ -1219,6 +1228,20 @@ mod subnet_info_tests {
     #[test]
     fn empty_trusted_relays_parses_to_empty_vec() {
         let cfg = make_subnet("10.0.0.0/24", vec![]);
+        let parsed = SubnetInfo::parse_trusted_relays(&cfg);
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn malformed_trusted_relays_are_dropped_not_panic() {
+        let cfg = make_subnet(
+            "10.0.0.0/24",
+            vec![
+                "not-an-ip".to_string(),
+                "10.0.0.500".to_string(),
+                "256.1.2.3".to_string(),
+            ],
+        );
         let parsed = SubnetInfo::parse_trusted_relays(&cfg);
         assert!(parsed.is_empty());
     }

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -1007,7 +1007,9 @@ impl<H: HaBackend> DhcpV4Server<H> {
         )
     }
 
-    /// Check if giaddr matches any known subnet (true relay vs perfdhcp loopback)
+    /// Defense-in-depth: re-checks the giaddr-in-subnet predicate that
+    /// `classify_relayed` already enforced for relayed packets. Kept because
+    /// `reply_destination` is called for non-relayed paths too.
     fn is_known_relay(&self, giaddr: Ipv4Addr) -> bool {
         self.subnets.iter().any(|s| {
             ip_in_subnet(

--- a/src/dhcpv4/stats.rs
+++ b/src/dhcpv4/stats.rs
@@ -1,6 +1,6 @@
 //! Atomic counters for DHCPv4 relay observability.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 
 /// Prometheus-exposed counters for DHCPv4 relay handling.
 #[derive(Default)]
@@ -25,31 +25,27 @@ impl DhcpV4Stats {
         Self::default()
     }
 
-    /// Read the current value of a counter (Relaxed ordering — metrics are
-    /// observational and do not need happens-before with other state).
-    pub fn load(counter: &AtomicU64) -> u64 {
-        counter.load(Ordering::Relaxed)
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn counters_start_at_zero() {
         let s = DhcpV4Stats::new();
-        assert_eq!(DhcpV4Stats::load(&s.relayed_received), 0);
-        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_disabled), 0);
-        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_bad_giaddr), 0);
-        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_untrusted_relay), 0);
-        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_rate_limit), 0);
+        assert_eq!(s.relayed_received.load(Ordering::Relaxed), 0);
+        assert_eq!(s.relayed_dropped_disabled.load(Ordering::Relaxed), 0);
+        assert_eq!(s.relayed_dropped_bad_giaddr.load(Ordering::Relaxed), 0);
+        assert_eq!(s.relayed_dropped_untrusted_relay.load(Ordering::Relaxed), 0);
+        assert_eq!(s.relayed_dropped_rate_limit.load(Ordering::Relaxed), 0);
     }
 
     #[test]
     fn counters_increment() {
         let s = DhcpV4Stats::new();
         s.relayed_received.fetch_add(3, Ordering::Relaxed);
-        assert_eq!(DhcpV4Stats::load(&s.relayed_received), 3);
+        assert_eq!(s.relayed_received.load(Ordering::Relaxed), 3);
     }
 }

--- a/src/dhcpv4/stats.rs
+++ b/src/dhcpv4/stats.rs
@@ -1,0 +1,55 @@
+//! Atomic counters for DHCPv4 relay observability.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Prometheus-exposed counters for DHCPv4 relay handling.
+#[derive(Default)]
+#[allow(dead_code)]
+pub struct DhcpV4Stats {
+    /// Total packets received with `giaddr != 0` (before security checks).
+    pub relayed_received: AtomicU64,
+    /// Relayed packets dropped because `accept_relayed = false`.
+    pub relayed_dropped_disabled: AtomicU64,
+    /// Relayed packets dropped because `giaddr` is a bogon or does not match any configured subnet.
+    pub relayed_dropped_bad_giaddr: AtomicU64,
+    /// Relayed packets dropped because the UDP source IP is not in the subnet's `trusted_relays`.
+    pub relayed_dropped_untrusted_relay: AtomicU64,
+    /// Relayed packets dropped by the per-relay-source rate limiter.
+    pub relayed_dropped_rate_limit: AtomicU64,
+}
+
+#[allow(dead_code)]
+impl DhcpV4Stats {
+    /// Create a new zeroed stats counter set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Read the current value of a counter (Relaxed ordering — metrics are
+    /// observational and do not need happens-before with other state).
+    pub fn load(counter: &AtomicU64) -> u64 {
+        counter.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counters_start_at_zero() {
+        let s = DhcpV4Stats::new();
+        assert_eq!(DhcpV4Stats::load(&s.relayed_received), 0);
+        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_disabled), 0);
+        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_bad_giaddr), 0);
+        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_untrusted_relay), 0);
+        assert_eq!(DhcpV4Stats::load(&s.relayed_dropped_rate_limit), 0);
+    }
+
+    #[test]
+    fn counters_increment() {
+        let s = DhcpV4Stats::new();
+        s.relayed_received.fetch_add(3, Ordering::Relaxed);
+        assert_eq!(DhcpV4Stats::load(&s.relayed_received), 3);
+    }
+}

--- a/src/dhcpv4/stats.rs
+++ b/src/dhcpv4/stats.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::AtomicU64;
 
 /// Prometheus-exposed counters for DHCPv4 relay handling.
 #[derive(Default)]
-#[allow(dead_code)]
 pub struct DhcpV4Stats {
     /// Total packets received with `giaddr != 0` (before security checks).
     pub relayed_received: AtomicU64,
@@ -18,7 +17,6 @@ pub struct DhcpV4Stats {
     pub relayed_dropped_rate_limit: AtomicU64,
 }
 
-#[allow(dead_code)]
 impl DhcpV4Stats {
     /// Create a new zeroed stats counter set.
     pub fn new() -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.global.rogue_threshold,
         config.global.rogue_window_secs,
     ));
+    let relay_rate_limiter = Arc::new(RateLimiter::new(
+        config.global.rate_limit_burst,
+        config.global.rate_limit_pps,
+    ));
+    let dhcpv4_stats = Arc::new(rdhcpd::dhcpv4::stats::DhcpV4Stats::new());
     info!(
         rate_limit_burst = config.global.rate_limit_burst,
         rate_limit_pps = config.global.rate_limit_pps,
@@ -355,6 +360,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 rate_limiter.clone(),
                 global_rate_limiter.clone(),
                 rogue_detector.clone(),
+                relay_rate_limiter.clone(),
+                dhcpv4_stats.clone(),
             );
 
             let worker_sender = sender.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ha: ha.clone(),
             wal: wal.clone(),
             api_key: api_config.api_key.as_deref().map(|s| s.to_string()),
+            dhcpv4_stats: dhcpv4_stats.clone(),
         });
 
         let listen = api_config.listen.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,8 +91,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.global.rogue_window_secs,
     ));
     let relay_rate_limiter = Arc::new(RateLimiter::new(
-        config.global.rate_limit_burst,
-        config.global.rate_limit_pps,
+        config.global.relay_rate_limit_burst,
+        config.global.relay_rate_limit_pps,
     ));
     let dhcpv4_stats = Arc::new(rdhcpd::dhcpv4::stats::DhcpV4Stats::new());
     info!(
@@ -101,6 +101,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         global_rate_limit = config.global.global_rate_limit_pps,
         rogue_threshold = config.global.rogue_threshold,
         "security: rate limiting and rogue detection initialized"
+    );
+    info!(
+        relay_rate_limit_burst = config.global.relay_rate_limit_burst,
+        relay_rate_limit_pps = config.global.relay_rate_limit_pps,
+        "security: per-relay-source rate limiter initialized"
     );
 
     let config = Arc::new(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,42 +315,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Spawn receive workers
         // -----------------------------------------------------------------
         for worker_id in 0..worker_count {
-            let recv_sock = socket2::Socket::new(
-                socket2::Domain::IPV4,
-                socket2::Type::DGRAM,
-                Some(socket2::Protocol::UDP),
-            )
-            .map_err(|e| format!("failed to create DHCPv4 recv socket: {}", e))?;
-            recv_sock.set_reuse_port(true)?;
-            recv_sock.set_broadcast(true)?;
-            recv_sock.set_nonblocking(true)?;
+            let bcast_bind = format!("255.255.255.255:{}", dhcpv4_port);
+            let any_bind = format!("0.0.0.0:{}", dhcpv4_port);
 
-            // FreeBSD: enable IP_BINDANY and bind to 255.255.255.255 so the socket
-            // receives broadcast DHCP packets (FreeBSD UDP sockets bound to 0.0.0.0
-            // don't receive link-layer broadcasts)
+            // Build sockets. On FreeBSD we need BOTH a 255.255.255.255:67
+            // socket (to receive link-layer broadcasts — the only way FreeBSD
+            // will deliver them to a UDP socket) AND a 0.0.0.0:67 socket (to
+            // receive unicast packets from a DHCP relay). On other platforms
+            // a single 0.0.0.0:67 catches both.
+            let mut sockets: Vec<Arc<UdpSocket>> = Vec::new();
             #[cfg(target_os = "freebsd")]
             {
-                let enable: libc::c_int = 1;
-                unsafe {
-                    libc::setsockopt(
-                        recv_sock.as_raw_fd(),
-                        libc::IPPROTO_IP,
-                        24, // IP_BINDANY
-                        &enable as *const _ as *const libc::c_void,
-                        std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-                    );
-                }
+                sockets.push(build_recv_socket(&bcast_bind, true)?);
+                sockets.push(build_recv_socket(&any_bind, false)?);
+            }
+            #[cfg(not(target_os = "freebsd"))]
+            {
+                let _ = &bcast_bind; // unused on non-FreeBSD
+                sockets.push(build_recv_socket(&any_bind, false)?);
             }
 
-            #[cfg(target_os = "freebsd")]
-            let bind_addr: std::net::SocketAddr = format!("255.255.255.255:{}", dhcpv4_port).parse().unwrap();
-            #[cfg(not(target_os = "freebsd"))]
-            let bind_addr: std::net::SocketAddr = format!("0.0.0.0:{}", dhcpv4_port).parse().unwrap();
-            recv_sock.bind(&bind_addr.into())
-                .map_err(|e| format!("failed to bind DHCPv4 port {}: {} (try running as root)", dhcpv4_port, e))?;
-            let recv_socket = Arc::new(UdpSocket::from_std(recv_sock.into())?);
-
-            let dhcpv4_server = DhcpV4Server::new(
+            let dhcpv4_server = Arc::new(DhcpV4Server::new(
                 config.clone(),
                 lease_store.clone(),
                 allocators.clone(),
@@ -362,14 +347,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 rogue_detector.clone(),
                 relay_rate_limiter.clone(),
                 dhcpv4_stats.clone(),
-            );
+            ));
 
-            let worker_sender = sender.clone();
-            dhcpv4_handles.push(tokio::spawn(async move {
-                if let Err(e) = dhcpv4_server.run(recv_socket, worker_sender).await {
-                    error!(error = %e, worker = worker_id, "DHCPv4 server error");
-                }
-            }));
+            for (sock_idx, recv_socket) in sockets.into_iter().enumerate() {
+                let server = dhcpv4_server.clone();
+                let worker_sender = sender.clone();
+                dhcpv4_handles.push(tokio::spawn(async move {
+                    if let Err(e) = server.run(recv_socket, worker_sender).await {
+                        error!(error = %e, worker = worker_id, sock_idx, "DHCPv4 server error");
+                    }
+                }));
+            }
         }
         info!(workers = worker_count, "DHCPv4 workers started");
     } else {
@@ -471,6 +459,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("WAL flushed, goodbye");
 
     Ok(())
+}
+
+/// Create a UDP receive socket for DHCPv4.
+///
+/// On FreeBSD, `freebsd_bindany` enables IP_BINDANY so the socket can bind to
+/// 255.255.255.255 (broadcast) or 0.0.0.0 (unicast relay) without holding those
+/// addresses.  On non-FreeBSD the flag is ignored.
+fn build_recv_socket(
+    bind_addr: &str,
+    freebsd_bindany: bool,
+) -> Result<Arc<UdpSocket>, Box<dyn std::error::Error>> {
+    let sock = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )
+    .map_err(|e| format!("failed to create DHCPv4 recv socket: {}", e))?;
+    sock.set_reuse_port(true)?;
+    sock.set_broadcast(true)?;
+    sock.set_nonblocking(true)?;
+
+    #[cfg(target_os = "freebsd")]
+    if freebsd_bindany {
+        let enable: libc::c_int = 1;
+        unsafe {
+            libc::setsockopt(
+                sock.as_raw_fd(),
+                libc::IPPROTO_IP,
+                24, // IP_BINDANY
+                &enable as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            );
+        }
+    }
+    #[cfg(not(target_os = "freebsd"))]
+    let _ = freebsd_bindany;
+
+    let addr: std::net::SocketAddr = bind_addr
+        .parse()
+        .map_err(|e| format!("invalid bind address {}: {}", bind_addr, e))?;
+    sock.bind(&addr.into())
+        .map_err(|e| format!("failed to bind DHCPv4 {}: {} (try running as root)", bind_addr, e))?;
+    Ok(Arc::new(UdpSocket::from_std(sock.into())?))
 }
 
 /// Create a UDP send socket for DHCPv4 replies (fallback when BPF is unavailable).

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -121,6 +121,39 @@ async fn make_server(
     (server, stats)
 }
 
+async fn make_server_with_relay_limit(
+    cfg: Config,
+    burst: u32,
+    pps: f64,
+) -> (DhcpV4Server<StandaloneBackend>, Arc<DhcpV4Stats>) {
+    let dir = tempdir_path();
+    let lease_store = LeaseStore::new();
+    let allocators = Arc::new(build_allocators(&cfg, &lease_store).unwrap());
+    let wal = Arc::new(Wal::open(&dir).await.unwrap());
+    let ha = Arc::new(StandaloneBackend);
+    let server_ip = Ipv4Addr::new(10, 0, 0, 1);
+    let rate_limiter = Arc::new(RateLimiter::new(100, 100.0));
+    let relay_rate_limiter = Arc::new(RateLimiter::new(burst, pps));
+    let rogue_detector = Arc::new(RogueDetector::new(1000, 60));
+    let stats = Arc::new(DhcpV4Stats::new());
+
+    let server = DhcpV4Server::new(
+        Arc::new(cfg),
+        lease_store,
+        allocators,
+        wal,
+        ha,
+        server_ip,
+        rate_limiter,
+        None, // global rate limiter disabled
+        rogue_detector,
+        relay_rate_limiter,
+        Arc::clone(&stats),
+    );
+
+    (server, stats)
+}
+
 fn relayed_discover(giaddr: Ipv4Addr) -> DhcpV4Packet {
     let mut p = DhcpV4Packet::new_discover([0xaa; 6]);
     p.giaddr = giaddr;
@@ -256,4 +289,26 @@ async fn empty_trusted_relays_accepts_any_source() {
     assert_eq!(decision, RelayDecision::Accept);
     use std::sync::atomic::Ordering;
     assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
+}
+
+/// Per-relay-source rate limiter exhaustion → DroppedRateLimit.
+#[tokio::test]
+async fn relayed_packets_are_rate_limited_per_source() {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200", vec![]);
+    let cfg = make_config(true, subnet);
+    // burst=1, very slow refill — second packet will exhaust the bucket
+    let (server, stats) = make_server_with_relay_limit(cfg, 1, 0.01).await;
+
+    let pkt = relayed_discover(Ipv4Addr::new(10, 0, 0, 5));
+    let relay_src = src_addr(Ipv4Addr::new(10, 0, 0, 5));
+
+    // First packet: consumes the single token → accepted
+    assert_eq!(server.classify_relayed(&pkt, relay_src), RelayDecision::Accept);
+    // Second packet: limiter empty → rate-limit drop
+    assert_eq!(server.classify_relayed(&pkt, relay_src), RelayDecision::DroppedRateLimit);
+    use std::sync::atomic::Ordering;
+    assert_eq!(
+        stats.relayed_dropped_rate_limit.load(Ordering::Relaxed),
+        1
+    );
 }

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -1,0 +1,257 @@
+//! Integration-style tests for the DHCPv4 relay security gates.
+//!
+//! Requires the `test-helpers` feature to access `DhcpV4Packet::new_discover`.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use rdhcpd::allocator::build_allocators;
+use rdhcpd::config::{Config, GlobalConfig, HaConfig, SubnetConfig};
+use rdhcpd::dhcpv4::packet::DhcpV4Packet;
+use rdhcpd::dhcpv4::server::{DhcpV4Server, RelayDecision};
+use rdhcpd::dhcpv4::stats::DhcpV4Stats;
+use rdhcpd::ha::StandaloneBackend;
+use rdhcpd::lease::store::LeaseStore;
+use rdhcpd::ratelimit::{RateLimiter, RogueDetector};
+use rdhcpd::wal::Wal;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn tempdir_path() -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "rdhcpd-test-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn make_subnet(
+    network: &str,
+    pool_start: &str,
+    pool_end: &str,
+    trusted_relays: Vec<String>,
+) -> SubnetConfig {
+    SubnetConfig {
+        network: network.to_string(),
+        pool_start: Some(pool_start.to_string()),
+        pool_end: Some(pool_end.to_string()),
+        lease_time: 3600,
+        max_lease_time: None,
+        renewal_time: None,
+        rebinding_time: None,
+        preferred_time: None,
+        subnet_type: "address".to_string(),
+        delegated_length: None,
+        router: None,
+        dns: vec![],
+        domain: None,
+        ip_probe: false,
+        ip_probe_timeout_ms: None,
+        max_leases_per_mac: 1,
+        mac_allow: vec![],
+        mac_deny: vec![],
+        trusted_relays,
+        reservation: vec![],
+    }
+}
+
+fn make_global(accept_relayed: bool) -> GlobalConfig {
+    GlobalConfig {
+        log_level: "info".to_string(),
+        log_format: "text".to_string(),
+        lease_db: "/tmp/rdhcpd-test".to_string(),
+        workers: 1,
+        rate_limit_burst: 100,
+        rate_limit_pps: 100.0,
+        global_rate_limit_pps: 0.0,
+        rogue_threshold: 1000,
+        rogue_window_secs: 60,
+        pool_high_water: 0.9,
+        accept_relayed,
+    }
+}
+
+fn make_config(accept_relayed: bool, subnet: SubnetConfig) -> Config {
+    Config {
+        global: make_global(accept_relayed),
+        api: None,
+        ha: HaConfig::Standalone,
+        subnet: vec![subnet],
+        ddns: None,
+    }
+}
+
+async fn make_server(
+    cfg: Config,
+) -> (DhcpV4Server<StandaloneBackend>, Arc<DhcpV4Stats>) {
+    let dir = tempdir_path();
+    let lease_store = LeaseStore::new();
+    let allocators = Arc::new(build_allocators(&cfg, &lease_store).unwrap());
+    let wal = Arc::new(Wal::open(&dir).await.unwrap());
+    let ha = Arc::new(StandaloneBackend);
+    let server_ip = Ipv4Addr::new(10, 0, 0, 1);
+    let rate_limiter = Arc::new(RateLimiter::new(100, 100.0));
+    let relay_rate_limiter = Arc::new(RateLimiter::new(100, 100.0));
+    let rogue_detector = Arc::new(RogueDetector::new(1000, 60));
+    let stats = Arc::new(DhcpV4Stats::new());
+
+    let server = DhcpV4Server::new(
+        Arc::new(cfg),
+        lease_store,
+        allocators,
+        wal,
+        ha,
+        server_ip,
+        rate_limiter,
+        None, // global rate limiter disabled
+        rogue_detector,
+        relay_rate_limiter,
+        Arc::clone(&stats),
+    );
+
+    (server, stats)
+}
+
+fn relayed_discover(giaddr: Ipv4Addr) -> DhcpV4Packet {
+    let mut p = DhcpV4Packet::new_discover([0xaa; 6]);
+    p.giaddr = giaddr;
+    p
+}
+
+fn src_addr(ip: Ipv4Addr) -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(ip), 1234)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Non-relayed packet (giaddr=0.0.0.0) always gets NotRelayed — gates skipped.
+#[tokio::test]
+async fn direct_broadcast_packets_bypass_relay_gates() {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200", vec![]);
+    let cfg = make_config(false, subnet); // accept_relayed=false should NOT matter
+    let (server, stats) = make_server(cfg).await;
+
+    let packet = DhcpV4Packet::new_discover([0xbb; 6]); // giaddr stays 0.0.0.0
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(192, 168, 1, 1)));
+
+    assert_eq!(decision, RelayDecision::NotRelayed);
+    // No stats should have been touched
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 0);
+}
+
+/// When `accept_relayed = false`, any relayed packet is dropped.
+#[tokio::test]
+async fn accept_relayed_disabled_drops_relayed_packets() {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200", vec![]);
+    let cfg = make_config(false, subnet);
+    let (server, stats) = make_server(cfg).await;
+
+    let packet = relayed_discover(Ipv4Addr::new(10, 0, 0, 1));
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(10, 0, 0, 5)));
+
+    assert_eq!(decision, RelayDecision::DroppedDisabled);
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.relayed_dropped_disabled.load(Ordering::Relaxed), 1);
+}
+
+/// Bogon giaddr (loopback 127.0.0.1) is rejected.
+#[tokio::test]
+async fn bogon_giaddr_is_dropped() {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200", vec![]);
+    let cfg = make_config(true, subnet);
+    let (server, stats) = make_server(cfg).await;
+
+    let packet = relayed_discover(Ipv4Addr::new(127, 0, 0, 1));
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(10, 0, 0, 5)));
+
+    assert_eq!(decision, RelayDecision::DroppedBadGiaddr);
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.relayed_dropped_bad_giaddr.load(Ordering::Relaxed), 1);
+}
+
+/// giaddr that doesn't match any configured subnet is dropped.
+#[tokio::test]
+async fn unknown_subnet_giaddr_is_dropped() {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200", vec![]);
+    let cfg = make_config(true, subnet);
+    let (server, stats) = make_server(cfg).await;
+
+    // giaddr is in 192.168.1.0/24 — not configured
+    let packet = relayed_discover(Ipv4Addr::new(192, 168, 1, 50));
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(192, 168, 1, 1)));
+
+    assert_eq!(decision, RelayDecision::DroppedBadGiaddr);
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_dropped_bad_giaddr.load(Ordering::Relaxed), 1);
+}
+
+/// Source IP not in trusted_relays list → DroppedUntrustedRelay.
+#[tokio::test]
+async fn untrusted_relay_source_is_dropped_when_whitelist_populated() {
+    let subnet = make_subnet(
+        "10.0.0.0/24",
+        "10.0.0.100",
+        "10.0.0.200",
+        vec!["10.0.0.5".to_string(), "10.0.0.6".to_string()],
+    );
+    let cfg = make_config(true, subnet);
+    let (server, stats) = make_server(cfg).await;
+
+    // giaddr matches the subnet, but source IP 10.0.0.99 is not trusted
+    let packet = relayed_discover(Ipv4Addr::new(10, 0, 0, 1));
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(10, 0, 0, 99)));
+
+    assert_eq!(decision, RelayDecision::DroppedUntrustedRelay);
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.relayed_dropped_untrusted_relay.load(Ordering::Relaxed), 1);
+}
+
+/// Source IP in trusted_relays → Accept.
+#[tokio::test]
+async fn trusted_relay_source_is_accepted() {
+    let subnet = make_subnet(
+        "10.0.0.0/24",
+        "10.0.0.100",
+        "10.0.0.200",
+        vec!["10.0.0.5".to_string()],
+    );
+    let cfg = make_config(true, subnet);
+    let (server, stats) = make_server(cfg).await;
+
+    let packet = relayed_discover(Ipv4Addr::new(10, 0, 0, 1));
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(10, 0, 0, 5)));
+
+    assert_eq!(decision, RelayDecision::Accept);
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.relayed_dropped_untrusted_relay.load(Ordering::Relaxed), 0);
+}
+
+/// Empty trusted_relays list → any relay source is accepted.
+#[tokio::test]
+async fn empty_trusted_relays_accepts_any_source() {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200", vec![]);
+    let cfg = make_config(true, subnet);
+    let (server, stats) = make_server(cfg).await;
+
+    let packet = relayed_discover(Ipv4Addr::new(10, 0, 0, 1));
+    // Source IP is completely arbitrary — no whitelist
+    let decision = server.classify_relayed(&packet, src_addr(Ipv4Addr::new(1, 2, 3, 4)));
+
+    assert_eq!(decision, RelayDecision::Accept);
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
+}

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -75,6 +75,8 @@ fn make_global(accept_relayed: bool) -> GlobalConfig {
         rogue_window_secs: 60,
         pool_high_water: 0.9,
         accept_relayed,
+        relay_rate_limit_burst: 100,
+        relay_rate_limit_pps: 100.0,
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #57. Also fixes #59 (all follow-up findings from the initial security/perf review are now addressed in this PR).

- On FreeBSD the server now binds a second receive socket to `0.0.0.0:67` alongside the existing `255.255.255.255:67` bind, so relayed unicast DHCP requests (`giaddr != 0`) are received instead of being silently dropped.
- `[global] accept_relayed` kill-switch, per-`[[subnet]] trusted_relays` source-IP whitelist.
- giaddr bogon check + subnet membership requirement.
- Dedicated per-relay-source rate limiter with its own config knobs (`relay_rate_limit_burst` default 200, `relay_rate_limit_pps` default 100.0 — calibrated for relays aggregating many clients, not per-MAC).
- Malformed `trusted_relays` entries now log a warning at startup (previously dropped silently).
- Bad-giaddr and untrusted-relay drops log at `debug!` rather than `warn!` (they fire before the per-relay rate limiter; counters remain authoritative).
- Prometheus counters: `rdhcpd_dhcpv4_relayed_received_total` and `rdhcpd_dhcpv4_relayed_dropped_total{reason=accept_relayed_disabled|bad_giaddr|untrusted_relay|rate_limit}`.

## Test plan

- [x] 32 lib unit tests pass.
- [x] 8 integration tests in tests/dhcpv4_relay_gates.rs cover every RelayDecision branch (incl. DroppedRateLimit).
- [x] cargo check --all-targets and cargo check --all-targets --features test-helpers both clean.
- [x] Linux path spawns one task per worker bound to 0.0.0.0:67 — unchanged from today.
- [ ] Manual FreeBSD smoke test with a Juniper EX2300 relay (per issue repro).
- [ ] bench/run.sh direct-broadcast DORA throughput before/after.