### PR TITLE
Per-subnet DHCP option overrides (ntp + generic table) (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to rDHCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-04-17
+
+### Added
+- Per-subnet `ntp = [...]` field — emits DHCP option 42 (NTP servers) on offers/acks/inform. Mirrors the existing `dns` field.
+- Per-subnet `[[subnet.option]]` generic DHCP option override table. Each entry specifies a `code` plus exactly one of `ip` / `ips` / `string` / `u8` / `u16` / `u32` / `hex`. Enables setting any DHCPv4 option (e.g. TFTP 66, bootfile 67, WPAD 252, vendor 43) per subnet without a code change.
+- Config-load validation for option overrides: reserved codes rejected (0, 1, 28, 50, 51, 53, 54, 55, 57, 58, 59, 82, 255), duplicates rejected, conflicts with typed `router`/`dns`/`domain`/`ntp` rejected, empty payloads rejected, hex decoded and length-bounded (≤255 bytes).
+- (Fixes #60.)
+
 ## [0.12.5] - 2026-04-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.12.9"
+version = "0.13.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.12.1"
+version = "0.12.9"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.12.9"
+version = "0.13.0"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/example-config.toml
+++ b/example-config.toml
@@ -75,6 +75,7 @@ max_lease_time = 172800           # cap client-requested lease time to 48h
 router = "10.0.1.1"
 dns = ["10.0.0.53", "10.0.0.54"]
 domain = "example.com"
+ntp = ["10.0.1.1"]                # NTP servers (DHCP option 42); mirrors `dns`
 
 # --- Per-Subnet Security ---
 max_leases_per_mac = 1            # max active leases per MAC (0 = unlimited)
@@ -102,6 +103,39 @@ hostname = "server"
 # client_id = "01aabbccddeef3"    # option 61 client identifier (hex)
 # ip = "10.0.1.12"
 # hostname = "laptop"
+
+# --- Generic DHCP option overrides ---
+# Per-subnet overrides for any DHCP option not covered by a typed field above.
+# Each [[subnet.option]] entry has a `code` plus EXACTLY ONE value form:
+#   ip = "1.2.3.4"                        single IPv4 (4 bytes)
+#   ips = ["1.2.3.4", "5.6.7.8"]          list of IPv4 (n*4 bytes)
+#   string = "..."                        ASCII string (<=255 bytes)
+#   u8 = 64                               single byte
+#   u16 = 1500                            big-endian u16
+#   u32 = 3600                            big-endian u32
+#   hex = "deadbeef"                      arbitrary bytes (<=255 bytes, even-length)
+# Reserved codes (server-managed): 0, 1, 28, 51, 53, 54, 58, 59, 255.
+# Codes 3/6/15/42 conflict with the typed `router`/`dns`/`domain`/`ntp` fields — set one, not both.
+#
+# [[subnet.option]]
+# code = 66                               # TFTP server name
+# string = "tftp.corp.lan"
+#
+# [[subnet.option]]
+# code = 67                               # Bootfile name
+# string = "pxelinux.0"
+#
+# [[subnet.option]]
+# code = 252                              # WPAD URL
+# string = "http://wpad.corp.lan/wpad.dat"
+#
+# [[subnet.option]]
+# code = 23                               # IP TTL
+# u8 = 64
+#
+# [[subnet.option]]
+# code = 43                               # Vendor-specific (opaque binary)
+# hex = "0108..."
 
 # -----------------------------------------------------------------------------
 # IPv6 Subnet

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -165,6 +165,9 @@ pub struct SubnetConfig {
     /// DNS server addresses for clients.
     #[serde(default)]
     pub dns: Vec<String>,
+    /// NTP server addresses for clients (DHCP option 42).
+    #[serde(default)]
+    pub ntp: Vec<String>,
     /// DNS domain name for clients.
     pub domain: Option<String>,
 
@@ -450,5 +453,26 @@ trusted_relays = ["10.0.1.5", "10.0.1.6"]
         let c: Config = toml::from_str(toml).unwrap();
         assert!(c.subnet[0].trusted_relays.is_empty());
         assert_eq!(c.subnet[1].trusted_relays, vec!["10.0.1.5", "10.0.1.6"]);
+    }
+
+    #[test]
+    fn subnet_ntp_defaults_empty_and_can_be_set() {
+        let toml = r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+
+[[subnet]]
+network = "10.0.1.0/24"
+ntp = ["10.0.0.1", "10.0.0.2"]
+"#;
+        let c: Config = toml::from_str(toml).unwrap();
+        assert!(c.subnet[0].ntp.is_empty());
+        assert_eq!(c.subnet[1].ntp, vec!["10.0.0.1", "10.0.0.2"]);
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -196,6 +196,37 @@ pub struct SubnetConfig {
     /// Static address reservations for specific clients.
     #[serde(default)]
     pub reservation: Vec<ReservationConfig>,
+
+    // Extended options
+    /// Generic DHCP option overrides for this subnet.
+    #[serde(default)]
+    pub option: Vec<OptionOverride>,
+}
+
+/// Per-subnet generic DHCP option override. Exactly ONE of the value
+/// fields must be set; the rest must be None.
+#[derive(Debug, Deserialize, Clone)]
+pub struct OptionOverride {
+    /// DHCP option code (RFC 2132 registry).
+    pub code: u8,
+    /// Single IPv4 address (4 bytes on wire).
+    pub ip: Option<String>,
+    /// List of IPv4 addresses (n*4 bytes on wire).
+    #[serde(default)]
+    pub ips: Option<Vec<String>>,
+    /// ASCII string value.
+    pub string: Option<String>,
+    /// Unsigned 8-bit integer.
+    #[serde(rename = "u8")]
+    pub u8_val: Option<u8>,
+    /// Unsigned 16-bit big-endian integer.
+    #[serde(rename = "u16")]
+    pub u16_val: Option<u16>,
+    /// Unsigned 32-bit big-endian integer.
+    #[serde(rename = "u32")]
+    pub u32_val: Option<u32>,
+    /// Arbitrary bytes encoded as hex (e.g. "deadbeef").
+    pub hex: Option<String>,
 }
 
 /// Static address reservation configuration for a specific client.

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -73,6 +73,9 @@ pub fn serialize_option_override(o: &OptionOverride) -> Result<Vec<u8>, String> 
                 .map_err(|_| format!("ips entry '{}' is not a valid IPv4 address", s))?;
             bytes.extend_from_slice(&addr.octets());
         }
+        if bytes.is_empty() {
+            return Err(format!("option code {}: value cannot be empty", o.code));
+        }
         return Ok(bytes);
     }
 
@@ -85,6 +88,9 @@ pub fn serialize_option_override(o: &OptionOverride) -> Result<Vec<u8>, String> 
         }
         if !s.bytes().all(|b| b.is_ascii_graphic() || b == b' ') {
             return Err("string value must contain only printable ASCII characters".to_string());
+        }
+        if s.is_empty() {
+            return Err(format!("option code {}: value cannot be empty", o.code));
         }
         return Ok(s.as_bytes().to_vec());
     }
@@ -103,6 +109,9 @@ pub fn serialize_option_override(o: &OptionOverride) -> Result<Vec<u8>, String> 
 
     if let Some(ref s) = o.hex {
         let bytes = decode_hex(s)?;
+        if bytes.is_empty() {
+            return Err(format!("option code {}: value cannot be empty", o.code));
+        }
         if bytes.len() > 255 {
             return Err(format!(
                 "hex value is {} bytes, maximum is 255",
@@ -636,6 +645,33 @@ mod option_override_tests {
         };
         assert!(serialize_option_override(&o).is_err());
     }
+
+    #[test]
+    fn empty_hex_is_rejected() {
+        let o = OptionOverride {
+            hex: Some("".to_string()),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err());
+    }
+
+    #[test]
+    fn empty_ips_is_rejected() {
+        let o = OptionOverride {
+            ips: Some(vec![]),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err());
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let o = OptionOverride {
+            string: Some("".to_string()),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err());
+    }
 }
 
 #[cfg(test)]
@@ -741,5 +777,77 @@ ips = ["10.0.0.2"]
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("ntp"), "expected 'ntp' in: {}", msg);
+    }
+
+    #[test]
+    fn option_code_3_conflicts_with_typed_router() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+router = "10.0.0.1"
+
+[[subnet.option]]
+code = 3
+ip = "10.0.0.2"
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("router"), "expected 'router' in: {}", msg);
+    }
+
+    #[test]
+    fn option_code_6_conflicts_with_typed_dns() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+dns = ["10.0.0.1"]
+
+[[subnet.option]]
+code = 6
+ips = ["10.0.0.2"]
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("dns"), "expected 'dns' in: {}", msg);
+    }
+
+    #[test]
+    fn option_code_15_conflicts_with_typed_domain() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+domain = "example.com"
+
+[[subnet.option]]
+code = 15
+string = "other.example"
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("domain"), "expected 'domain' in: {}", msg);
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -2,7 +2,118 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use tracing::warn;
 
+use super::types::OptionOverride;
 use super::{Config, ConfigError};
+
+/// Decode a hex string (without separators) into bytes.
+/// Rejects odd-length strings and non-hex characters.
+fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
+    let s = s.trim();
+    if s.len() % 2 != 0 {
+        return Err(format!(
+            "hex string must have even length, got {}",
+            s.len()
+        ));
+    }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for chunk in s.as_bytes().chunks(2) {
+        let hi = (chunk[0] as char)
+            .to_digit(16)
+            .ok_or_else(|| "invalid hex char".to_string())?;
+        let lo = (chunk[1] as char)
+            .to_digit(16)
+            .ok_or_else(|| "invalid hex char".to_string())?;
+        out.push(((hi << 4) | lo) as u8);
+    }
+    Ok(out)
+}
+
+/// Serialize an `OptionOverride` value into the raw bytes that will be placed
+/// in the DHCP option payload (excluding code and length bytes).
+///
+/// Exactly one of the value fields (`ip`, `ips`, `string`, `u8_val`,
+/// `u16_val`, `u32_val`, `hex`) must be `Some`; all others must be `None`.
+pub fn serialize_option_override(o: &OptionOverride) -> Result<Vec<u8>, String> {
+    // Count how many value fields are set
+    let set_count = [
+        o.ip.is_some(),
+        o.ips.is_some(),
+        o.string.is_some(),
+        o.u8_val.is_some(),
+        o.u16_val.is_some(),
+        o.u32_val.is_some(),
+        o.hex.is_some(),
+    ]
+    .iter()
+    .filter(|&&v| v)
+    .count();
+
+    if set_count == 0 {
+        return Err("exactly one value field must be set (none found)".to_string());
+    }
+    if set_count > 1 {
+        return Err(format!(
+            "exactly one value field must be set ({} found)",
+            set_count
+        ));
+    }
+
+    if let Some(ref s) = o.ip {
+        let addr: Ipv4Addr = s
+            .parse()
+            .map_err(|_| format!("ip '{}' is not a valid IPv4 address", s))?;
+        return Ok(addr.octets().to_vec());
+    }
+
+    if let Some(ref list) = o.ips {
+        let mut bytes = Vec::with_capacity(list.len() * 4);
+        for s in list {
+            let addr: Ipv4Addr = s
+                .parse()
+                .map_err(|_| format!("ips entry '{}' is not a valid IPv4 address", s))?;
+            bytes.extend_from_slice(&addr.octets());
+        }
+        return Ok(bytes);
+    }
+
+    if let Some(ref s) = o.string {
+        if s.len() > 255 {
+            return Err(format!(
+                "string value is {} bytes, maximum is 255",
+                s.len()
+            ));
+        }
+        if !s.bytes().all(|b| b.is_ascii_graphic() || b == b' ') {
+            return Err("string value must contain only printable ASCII characters".to_string());
+        }
+        return Ok(s.as_bytes().to_vec());
+    }
+
+    if let Some(v) = o.u8_val {
+        return Ok(vec![v]);
+    }
+
+    if let Some(v) = o.u16_val {
+        return Ok(v.to_be_bytes().to_vec());
+    }
+
+    if let Some(v) = o.u32_val {
+        return Ok(v.to_be_bytes().to_vec());
+    }
+
+    if let Some(ref s) = o.hex {
+        let bytes = decode_hex(s)?;
+        if bytes.len() > 255 {
+            return Err(format!(
+                "hex value is {} bytes, maximum is 255",
+                bytes.len()
+            ));
+        }
+        return Ok(bytes);
+    }
+
+    unreachable!("set_count == 1 but no field matched")
+}
 
 pub fn validate(config: &Config) -> Result<(), ConfigError> {
     validate_subnets(config)?;
@@ -97,6 +208,54 @@ fn validate_subnets(config: &Config) -> Result<(), ConfigError> {
                     i, subnet.network
                 )));
             }
+        }
+
+        // Validate generic DHCP option overrides
+        let mut seen_codes = std::collections::HashSet::new();
+        for (k, opt) in subnet.option.iter().enumerate() {
+            // Reserved codes the server controls
+            const RESERVED: &[u8] = &[0, 1, 28, 51, 53, 54, 58, 59, 255];
+            if RESERVED.contains(&opt.code) {
+                return Err(ConfigError::Validation(format!(
+                    "subnet[{}] option[{}]: code {} is reserved and managed by the server",
+                    i, k, opt.code
+                )));
+            }
+            // No duplicates within a subnet
+            if !seen_codes.insert(opt.code) {
+                return Err(ConfigError::Validation(format!(
+                    "subnet[{}] option[{}]: duplicate entry for code {}",
+                    i, k, opt.code
+                )));
+            }
+            // Collision with typed fields only if the typed field is non-empty
+            match opt.code {
+                3 /* router */ if subnet.router.is_some() =>
+                    return Err(ConfigError::Validation(format!(
+                        "subnet[{}] option[{}]: code 3 conflicts with `router` (set one, not both)",
+                        i, k
+                    ))),
+                6 /* dns */ if !subnet.dns.is_empty() =>
+                    return Err(ConfigError::Validation(format!(
+                        "subnet[{}] option[{}]: code 6 conflicts with `dns` (set one, not both)",
+                        i, k
+                    ))),
+                15 /* domain */ if subnet.domain.is_some() =>
+                    return Err(ConfigError::Validation(format!(
+                        "subnet[{}] option[{}]: code 15 conflicts with `domain` (set one, not both)",
+                        i, k
+                    ))),
+                42 /* ntp */ if !subnet.ntp.is_empty() =>
+                    return Err(ConfigError::Validation(format!(
+                        "subnet[{}] option[{}]: code 42 conflicts with `ntp` (set one, not both)",
+                        i, k
+                    ))),
+                _ => {}
+            }
+            // Value form + bytes validation
+            serialize_option_override(opt).map_err(|e| {
+                ConfigError::Validation(format!("subnet[{}] option[{}]: {}", i, k, e))
+            })?;
         }
 
         // Validate reservations
@@ -362,5 +521,225 @@ mod giaddr_tests {
         assert!(!is_bogon_giaddr(Ipv4Addr::new(10, 0, 0, 1)));
         assert!(!is_bogon_giaddr(Ipv4Addr::new(192, 168, 1, 1)));
         assert!(!is_bogon_giaddr(Ipv4Addr::new(172, 29, 69, 5)));
+    }
+}
+
+#[cfg(test)]
+mod option_override_tests {
+    use super::*;
+    use crate::config::types::OptionOverride;
+
+    fn base() -> OptionOverride {
+        OptionOverride {
+            code: 42,
+            ip: None,
+            ips: None,
+            string: None,
+            u8_val: None,
+            u16_val: None,
+            u32_val: None,
+            hex: None,
+        }
+    }
+
+    #[test]
+    fn exactly_one_value_required() {
+        let o = base();
+        assert!(serialize_option_override(&o).is_err()); // none
+        let o = OptionOverride {
+            ip: Some("1.2.3.4".to_string()),
+            string: Some("x".to_string()),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err()); // two
+    }
+
+    #[test]
+    fn ip_serializes_to_4_bytes() {
+        let o = OptionOverride {
+            ip: Some("10.0.0.1".to_string()),
+            ..base()
+        };
+        let bytes = serialize_option_override(&o).unwrap();
+        assert_eq!(bytes, vec![10, 0, 0, 1]);
+    }
+
+    #[test]
+    fn ips_serializes_to_n_times_4_bytes() {
+        let o = OptionOverride {
+            ips: Some(vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()]),
+            ..base()
+        };
+        let bytes = serialize_option_override(&o).unwrap();
+        assert_eq!(bytes, vec![10, 0, 0, 1, 10, 0, 0, 2]);
+    }
+
+    #[test]
+    fn string_must_be_ascii_printable_and_255_max() {
+        let o = OptionOverride {
+            string: Some("hello".to_string()),
+            ..base()
+        };
+        assert_eq!(serialize_option_override(&o).unwrap(), b"hello".to_vec());
+        let long = "x".repeat(256);
+        let o = OptionOverride {
+            string: Some(long),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err());
+    }
+
+    #[test]
+    fn u8_u16_u32_big_endian() {
+        let o = OptionOverride {
+            u8_val: Some(64),
+            ..base()
+        };
+        assert_eq!(serialize_option_override(&o).unwrap(), vec![64]);
+        let o = OptionOverride {
+            u16_val: Some(0x1234),
+            ..base()
+        };
+        assert_eq!(serialize_option_override(&o).unwrap(), vec![0x12, 0x34]);
+        let o = OptionOverride {
+            u32_val: Some(0xdeadbeef),
+            ..base()
+        };
+        assert_eq!(
+            serialize_option_override(&o).unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+    }
+
+    #[test]
+    fn hex_decodes_lowercase_and_uppercase() {
+        let o = OptionOverride {
+            hex: Some("deadBEEF".to_string()),
+            ..base()
+        };
+        assert_eq!(
+            serialize_option_override(&o).unwrap(),
+            vec![0xde, 0xad, 0xbe, 0xef]
+        );
+    }
+
+    #[test]
+    fn hex_rejects_odd_length_and_nonhex() {
+        let o = OptionOverride {
+            hex: Some("abc".to_string()),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err());
+        let o = OptionOverride {
+            hex: Some("xx".to_string()),
+            ..base()
+        };
+        assert!(serialize_option_override(&o).is_err());
+    }
+}
+
+#[cfg(test)]
+mod config_option_tests {
+    use super::*;
+    use crate::config::{Config, ConfigError};
+
+    fn validate_toml(s: &str) -> Result<(), ConfigError> {
+        let c: Config = toml::from_str(s).map_err(ConfigError::Parse)?;
+        validate(&c)
+    }
+
+    #[test]
+    fn single_option_entry_parses_correctly() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+
+[[subnet.option]]
+code = 72
+ip = "10.0.0.1"
+"#,
+        );
+        assert!(result.is_ok(), "unexpected error: {:?}", result);
+    }
+
+    #[test]
+    fn reserved_code_is_rejected() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+
+[[subnet.option]]
+code = 53
+u8 = 1
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("reserved"), "expected 'reserved' in: {}", msg);
+    }
+
+    #[test]
+    fn duplicate_codes_are_rejected() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+
+[[subnet.option]]
+code = 72
+ip = "10.0.0.1"
+
+[[subnet.option]]
+code = 72
+ip = "10.0.0.2"
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("duplicate"), "expected 'duplicate' in: {}", msg);
+    }
+
+    #[test]
+    fn code_42_conflicts_with_ntp_field() {
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+ntp = ["10.0.0.1"]
+
+[[subnet.option]]
+code = 42
+ips = ["10.0.0.2"]
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("ntp"), "expected 'ntp' in: {}", msg);
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -222,8 +222,11 @@ fn validate_subnets(config: &Config) -> Result<(), ConfigError> {
         // Validate generic DHCP option overrides
         let mut seen_codes = std::collections::HashSet::new();
         for (k, opt) in subnet.option.iter().enumerate() {
-            // Reserved codes the server controls
-            const RESERVED: &[u8] = &[0, 1, 28, 51, 53, 54, 58, 59, 255];
+            // Reserved codes the server controls, or codes that are
+            // client→server / relay→server only and must not be emitted
+            // by the server (50=RequestedIP, 55=ParameterRequestList,
+            // 57=MaxMessageSize, 82=RelayAgentInfo).
+            const RESERVED: &[u8] = &[0, 1, 28, 50, 51, 53, 54, 55, 57, 58, 59, 82, 255];
             if RESERVED.contains(&opt.code) {
                 return Err(ConfigError::Validation(format!(
                     "subnet[{}] option[{}]: code {} is reserved and managed by the server",
@@ -721,6 +724,32 @@ network = "10.0.0.0/24"
 [[subnet.option]]
 code = 53
 u8 = 1
+"#,
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("reserved"), "expected 'reserved' in: {}", msg);
+    }
+
+    #[test]
+    fn client_only_codes_are_rejected() {
+        // Code 50 (Requested IP) is client→server only; the server must not
+        // emit it.  Verify that all four newly-added reserved codes are blocked
+        // by testing code 50 as a representative.
+        let result = validate_toml(
+            r#"
+[global]
+lease_db = "/tmp/x"
+
+[ha]
+mode = "standalone"
+
+[[subnet]]
+network = "10.0.0.0/24"
+
+[[subnet.option]]
+code = 50
+ip = "10.0.0.5"
 "#,
         );
         assert!(result.is_err());

--- a/src/dhcpv4/options.rs
+++ b/src/dhcpv4/options.rs
@@ -317,12 +317,15 @@ impl DhcpOption {
 
     /// Serialize all options into a buffer. Returns bytes written.
     /// Stops writing if the buffer is too small for the next option.
+    /// Uses `>=` (not `>`) so that at least 1 byte is always left for the
+    /// END terminator (0xFF) written by the caller after this returns.
     pub fn serialize_all(options: &[DhcpOption], buf: &mut [u8]) -> usize {
         let mut pos = 0;
 
         for opt in options {
             let needed = opt.serialized_len();
-            if pos + needed > buf.len() {
+            // Reserve 1 byte for the END terminator written by the caller.
+            if pos + needed >= buf.len() {
                 tracing::warn!(
                     option_code = opt.code(),
                     remaining_bytes = buf.len() - pos,
@@ -564,6 +567,24 @@ mod tests {
     fn ntp_servers_code_is_42() {
         let opt = DhcpOption::NtpServers(vec![Ipv4Addr::new(1, 2, 3, 4)]);
         assert_eq!(opt.code(), 42);
+    }
+
+    #[test]
+    fn serialize_all_reserves_room_for_end_terminator() {
+        // Craft an option whose serialized length would exactly fill the buffer.
+        // The check must reserve at least 1 byte so the caller's END-terminator
+        // write doesn't panic.
+        let opt = DhcpOption::Unknown(99, vec![0u8; 100]);
+        let needed = 2 + 100; // 102
+        let mut buf = vec![0u8; needed]; // exactly needed bytes — no room for END
+        let written = DhcpOption::serialize_all(&[opt], &mut buf);
+        // The option MUST NOT be written because we must leave 1 byte for END.
+        assert!(
+            written < needed,
+            "serialize_all wrote {} into a buffer of {}, leaving no room for END",
+            written,
+            needed
+        );
     }
 }
 

--- a/src/dhcpv4/options.rs
+++ b/src/dhcpv4/options.rs
@@ -557,7 +557,7 @@ mod tests {
         assert_eq!(&buf[..len], &[42, 8, 10, 0, 0, 1, 10, 0, 0, 2]);
         let parsed = DhcpOption::parse_all(&buf[..len]).unwrap();
         assert_eq!(parsed.len(), 1);
-        matches!(parsed[0], DhcpOption::NtpServers(_));
+        assert!(matches!(parsed[0], DhcpOption::NtpServers(_)));
     }
 
     #[test]

--- a/src/dhcpv4/options.rs
+++ b/src/dhcpv4/options.rs
@@ -79,6 +79,8 @@ pub mod code {
     pub const VENDOR_CLASS_ID: u8 = 60;
     /// Client identifier (option 61).
     pub const CLIENT_ID: u8 = 61;
+    /// NTP server addresses (option 42).
+    pub const NTP: u8 = 42;
     /// Relay agent information (option 82).
     pub const RELAY_AGENT_INFO: u8 = 82;
     /// End-of-options marker (option 255).
@@ -120,6 +122,8 @@ pub enum DhcpOption {
     VendorClassId(Vec<u8>),
     /// Client identifier (option 61).
     ClientIdentifier(Vec<u8>),
+    /// NTP server address(es) (option 42).
+    NtpServers(Vec<Ipv4Addr>),
     /// Relay agent information sub-options (option 82).
     RelayAgentInfo(Vec<u8>),
     /// Unknown option: (code, data)
@@ -190,6 +194,16 @@ impl DhcpOption {
                         .map(|c| Ipv4Addr::new(c[0], c[1], c[2], c[3]))
                         .collect();
                     DhcpOption::DnsServers(addrs)
+                }
+                code::NTP => {
+                    if opt_len % 4 != 0 || opt_len == 0 {
+                        return Err(PacketError::MalformedOption(pos));
+                    }
+                    let addrs = opt_data
+                        .chunks_exact(4)
+                        .map(|c| Ipv4Addr::new(c[0], c[1], c[2], c[3]))
+                        .collect();
+                    DhcpOption::NtpServers(addrs)
                 }
                 code::HOSTNAME => {
                     // Only accept printable ASCII hostnames; reject binary/non-ASCII data
@@ -332,6 +346,7 @@ impl DhcpOption {
             | DhcpOption::ServerIdentifier(_) => 6,
             DhcpOption::Router(addrs) => 2 + addrs.len().min(63) * 4,
             DhcpOption::DnsServers(addrs) => 2 + addrs.len().min(63) * 4,
+            DhcpOption::NtpServers(addrs) => 2 + addrs.len().min(63) * 4,
             DhcpOption::Hostname(name) => 2 + name.len().min(255),
             DhcpOption::DomainName(name) => 2 + name.len().min(255),
             DhcpOption::LeaseTime(_)
@@ -369,6 +384,16 @@ impl DhcpOption {
             }
             DhcpOption::DnsServers(addrs) => {
                 buf[0] = code::DNS;
+                let count = addrs.len().min(63);
+                let len = (count * 4) as u8;
+                buf[1] = len;
+                for (i, addr) in addrs.iter().take(count).enumerate() {
+                    buf[2 + i * 4..6 + i * 4].copy_from_slice(&addr.octets());
+                }
+                2 + len as usize
+            }
+            DhcpOption::NtpServers(addrs) => {
+                buf[0] = code::NTP;
                 let count = addrs.len().min(63);
                 let len = (count * 4) as u8;
                 buf[1] = len;
@@ -498,6 +523,7 @@ impl DhcpOption {
             DhcpOption::RebindingTime(_) => code::REBINDING_TIME,
             DhcpOption::VendorClassId(_) => code::VENDOR_CLASS_ID,
             DhcpOption::ClientIdentifier(_) => code::CLIENT_ID,
+            DhcpOption::NtpServers(_) => code::NTP,
             DhcpOption::RelayAgentInfo(_) => code::RELAY_AGENT_INFO,
             DhcpOption::Unknown(c, _) => *c,
         }
@@ -514,6 +540,31 @@ pub fn prefix_to_mask(prefix_len: u8) -> Ipv4Addr {
     }
     let mask = !((1u32 << (32 - prefix_len)) - 1);
     Ipv4Addr::from(mask.to_be_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ntp_servers_roundtrip() {
+        let opt = DhcpOption::NtpServers(vec![
+            Ipv4Addr::new(10, 0, 0, 1),
+            Ipv4Addr::new(10, 0, 0, 2),
+        ]);
+        let mut buf = [0u8; 16];
+        let len = opt.serialize(&mut buf);
+        assert_eq!(&buf[..len], &[42, 8, 10, 0, 0, 1, 10, 0, 0, 2]);
+        let parsed = DhcpOption::parse_all(&buf[..len]).unwrap();
+        assert_eq!(parsed.len(), 1);
+        matches!(parsed[0], DhcpOption::NtpServers(_));
+    }
+
+    #[test]
+    fn ntp_servers_code_is_42() {
+        let opt = DhcpOption::NtpServers(vec![Ipv4Addr::new(1, 2, 3, 4)]);
+        assert_eq!(opt.code(), 42);
+    }
 }
 
 /// Compute the broadcast address for a network

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -108,7 +108,6 @@ struct SubnetInfo {
     /// Pre-parsed trusted relay agent source IPs. Empty = accept any relay.
     trusted_relays: Arc<[Ipv4Addr]>,
     /// Pre-serialized generic DHCP option overrides: (code, bytes).
-    #[allow(dead_code)]
     custom_options: Arc<[(u8, Vec<u8>)]>,
 }
 
@@ -977,6 +976,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
             subnet.prefix_len,
         )));
 
+        // Append generic per-subnet option overrides (from `[[subnet.option]]`).
+        for (code, bytes) in subnet.custom_options.iter() {
+            opts.push(DhcpOption::Unknown(*code, bytes.clone()));
+        }
+
         opts
     }
 
@@ -1021,6 +1025,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
 
         if let Some(ref domain) = subnet.config.domain {
             opts.push(DhcpOption::DomainName(domain.clone()));
+        }
+
+        // Append generic per-subnet option overrides (from `[[subnet.option]]`).
+        for (code, bytes) in subnet.custom_options.iter() {
+            opts.push(DhcpOption::Unknown(*code, bytes.clone()));
         }
 
         opts
@@ -1288,5 +1297,66 @@ mod subnet_info_tests {
         );
         let parsed = SubnetInfo::parse_trusted_relays(&cfg);
         assert!(parsed.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod custom_options_tests {
+    use super::*;
+    use crate::config::OptionOverride;
+
+    /// Verify that DhcpOption::Unknown serializes the (code, bytes) pair correctly.
+    /// This is the emission path used for all custom options.
+    #[test]
+    fn unknown_option_serializes_correctly() {
+        let opt = DhcpOption::Unknown(72, vec![10, 0, 0, 5]);
+        let mut buf = [0u8; 16];
+        let len = opt.serialize(&mut buf);
+        // code=72, len=4, then 4 bytes of IP
+        assert_eq!(&buf[..len], &[72, 4, 10, 0, 0, 5]);
+    }
+
+    /// Verify that serialize_option_override produces the bytes that end up
+    /// in a DhcpOption::Unknown payload, and that they round-trip correctly
+    /// through the serializer.
+    #[test]
+    fn custom_option_roundtrip_via_unknown() {
+        let o = OptionOverride {
+            code: 72,
+            ip: Some("10.0.0.5".to_string()),
+            ips: None,
+            string: None,
+            u8_val: None,
+            u16_val: None,
+            u32_val: None,
+            hex: None,
+        };
+        let bytes =
+            crate::config::validation::serialize_option_override(&o).unwrap();
+        assert_eq!(bytes, vec![10, 0, 0, 5]);
+
+        // Wrap in Unknown and verify wire format
+        let opt = DhcpOption::Unknown(o.code, bytes);
+        let mut buf = [0u8; 16];
+        let len = opt.serialize(&mut buf);
+        assert_eq!(&buf[..len], &[72, 4, 10, 0, 0, 5]);
+    }
+
+    /// Verify that custom_options on SubnetInfo are pre-serialized and iterable
+    /// in the same form that build_offer_options uses.
+    #[test]
+    fn subnet_info_custom_options_arc_iteration() {
+        let raw: Vec<(u8, Vec<u8>)> = vec![
+            (72, vec![10, 0, 0, 1]),
+            (77, vec![104, 101, 108, 108, 111]), // "hello"
+        ];
+        let arc: Arc<[(u8, Vec<u8>)]> = Arc::from(raw);
+        let mut collected: Vec<DhcpOption> = Vec::new();
+        for (code, bytes) in arc.iter() {
+            collected.push(DhcpOption::Unknown(*code, bytes.clone()));
+        }
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected[0].code(), 72);
+        assert_eq!(collected[1].code(), 77);
     }
 }

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -107,6 +107,9 @@ struct SubnetInfo {
     mac_acl: Arc<MacAcl>,
     /// Pre-parsed trusted relay agent source IPs. Empty = accept any relay.
     trusted_relays: Arc<[Ipv4Addr]>,
+    /// Pre-serialized generic DHCP option overrides: (code, bytes).
+    #[allow(dead_code)]
+    custom_options: Arc<[(u8, Vec<u8>)]>,
 }
 
 impl SubnetInfo {
@@ -166,6 +169,19 @@ impl<H: HaBackend> DhcpV4Server<H> {
                         .collect();
                     let mac_acl = Arc::new(MacAcl::new(allow, deny));
 
+                    // Pre-serialize generic DHCP option overrides (validation already
+                    // ran at config load; this pass is infallible but uses filter_map
+                    // defensively).
+                    let custom_options: Vec<(u8, Vec<u8>)> = s
+                        .option
+                        .iter()
+                        .filter_map(|o| {
+                            crate::config::validation::serialize_option_override(o)
+                                .ok()
+                                .map(|bytes| (o.code, bytes))
+                        })
+                        .collect();
+
                     Some(SubnetInfo {
                         network: Arc::from(s.network.as_str()),
                         network_addr: v4,
@@ -173,6 +189,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
                         config: Arc::new(s.clone()),
                         mac_acl,
                         trusted_relays: Arc::from(SubnetInfo::parse_trusted_relays(s)),
+                        custom_options: Arc::from(custom_options),
                     })
                 } else {
                     None
@@ -1173,6 +1190,7 @@ mod relay_gate_tests {
             dns: vec![],
             ntp: vec![],
             domain: None,
+            option: vec![],
             ip_probe: false,
             ip_probe_timeout_ms: None,
             max_leases_per_mac: 1,
@@ -1188,6 +1206,7 @@ mod relay_gate_tests {
             config: Arc::new(cfg),
             mac_acl: Arc::new(MacAcl::new(vec![], vec![])),
             trusted_relays: Arc::from(trusted.as_slice()),
+            custom_options: Arc::from(Vec::<(u8, Vec<u8>)>::new()),
         }
     }
 
@@ -1229,6 +1248,7 @@ mod subnet_info_tests {
             dns: vec![],
             ntp: vec![],
             domain: None,
+            option: vec![],
             ip_probe: false,
             ip_probe_timeout_ms: None,
             max_leases_per_mac: 1,

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -941,6 +941,16 @@ impl<H: HaBackend> DhcpV4Server<H> {
             opts.push(DhcpOption::DnsServers(dns_addrs));
         }
 
+        let ntp_addrs: Vec<Ipv4Addr> = subnet
+            .config
+            .ntp
+            .iter()
+            .filter_map(|s| s.parse().ok())
+            .collect();
+        if !ntp_addrs.is_empty() {
+            opts.push(DhcpOption::NtpServers(ntp_addrs));
+        }
+
         if let Some(ref domain) = subnet.config.domain {
             opts.push(DhcpOption::DomainName(domain.clone()));
         }
@@ -980,6 +990,16 @@ impl<H: HaBackend> DhcpV4Server<H> {
             .collect();
         if !dns_addrs.is_empty() {
             opts.push(DhcpOption::DnsServers(dns_addrs));
+        }
+
+        let ntp_addrs: Vec<Ipv4Addr> = subnet
+            .config
+            .ntp
+            .iter()
+            .filter_map(|s| s.parse().ok())
+            .collect();
+        if !ntp_addrs.is_empty() {
+            opts.push(DhcpOption::NtpServers(ntp_addrs));
         }
 
         if let Some(ref domain) = subnet.config.domain {
@@ -1151,6 +1171,7 @@ mod relay_gate_tests {
             delegated_length: None,
             router: None,
             dns: vec![],
+            ntp: vec![],
             domain: None,
             ip_probe: false,
             ip_probe_timeout_ms: None,
@@ -1206,6 +1227,7 @@ mod subnet_info_tests {
             delegated_length: None,
             router: None,
             dns: vec![],
+            ntp: vec![],
             domain: None,
             ip_probe: false,
             ip_probe_timeout_ms: None,

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -51,6 +51,7 @@ fn make_subnet(
         delegated_length: None,
         router: None,
         dns: vec![],
+        ntp: vec![],
         domain: None,
         ip_probe: false,
         ip_probe_timeout_ms: None,

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -53,6 +53,7 @@ fn make_subnet(
         dns: vec![],
         ntp: vec![],
         domain: None,
+        option: vec![],
         ip_probe: false,
         ip_probe_timeout_ms: None,
         max_leases_per_mac: 1,


### PR DESCRIPTION
## Summary

Fixes #60.

- Adds typed `ntp = [...]` on `[[subnet]]` — emits DHCP option 42.
- Adds generic `[[subnet.option]]` table — each entry is `{ code: u8, <one of ip/ips/string/u8/u16/u32/hex> }`. Enables per-subnet overrides for any DHCP option not already covered by a typed field, without code changes.
- Config-load validation: reserved codes rejected, duplicates rejected, conflicts with typed fields rejected, empty payloads rejected, hex length-bounded.

Emitted via the existing `DhcpOption::Unknown(code, Vec<u8>)` serializer — no new wire-format code.

## Test plan

- [x] 35 lib tests pass (up from 12 on main).
- [x] `cargo check --all-targets` clean.
- [ ] Manual smoke: configure `ntp = [...]` on a subnet, issue a DHCPREQUEST with PRL containing 42, confirm option 42 in the OFFER.
- [ ] Manual smoke: configure `[[subnet.option]] code = 66, string = "tftp.example"`, confirm option 66 in the OFFER.

## Related

- AiFw: editor for the generic option table would be a good follow-up.