### PR TITLE
DHCP lease stickiness fixes + HA integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.14.6"
+version = "0.14.7"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "rdhcpd"
-version = "0.14.3"
+version = "0.14.5"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -485,13 +485,15 @@ impl<H: HaBackend> DhcpV4Server<H> {
             .await;
 
         // Check for existing lease for this client.
-        // Per RFC 2131 §4.2: if client_id (option 61) is present, use it as
-        // the primary lookup key; otherwise fall back to MAC.
-        let existing_lease = if let Some(cid) = packet.client_id() {
-            self.lease_store.get_by_client_id(cid)
-        } else {
-            self.lease_store.get_by_mac(&mac)
-        };
+        // Per RFC 2131 §4.2: client_id (option 61) is the primary lookup key
+        // when present. We *also* fall back to MAC on a cid miss so that a
+        // client whose option 61 rotates between sessions (common on OS
+        // reinstalls — same NIC, fresh DUID/client-id) still recovers its
+        // previous binding instead of being treated as a brand-new client.
+        let existing_lease = packet
+            .client_id()
+            .and_then(|cid| self.lease_store.get_by_client_id(cid))
+            .or_else(|| self.lease_store.get_by_mac(&mac));
 
         // Reservation takes precedence over any cached lease — otherwise a
         // MAC that already picked up a pool IP keeps renewing the pool IP

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -523,13 +523,43 @@ impl<H: HaBackend> DhcpV4Server<H> {
             return Ok(Some(reply));
         }
 
+        // RFC 2131 §4.3.1: prefer the client's current binding, else its
+        // previous (now expired/released) binding if that address is still in
+        // the pool and not held by another client. Honouring the second
+        // bullet keeps a returning client on its prior IP across an expiry
+        // window — a hard requirement for "OS reinstall keeps same IP".
         if let Some(existing) = existing_lease {
-            if existing.is_active() {
-                if let IpAddr::V4(v4) = existing.ip {
-                    // Offer the same IP they already have
-                    let options = self.build_offer_options(&subnet);
-                    let reply = packet.build_reply(MessageType::Offer, v4, self.server_ip, options);
-                    return Ok(Some(reply));
+            if let IpAddr::V4(v4) = existing.ip {
+                if let Some(allocator) = self.allocators.get(&*subnet.network) {
+                    if allocator.contains(&existing.ip) {
+                        let offer_same = if existing.is_active() {
+                            // Already ours in the bitmap — nothing to reclaim.
+                            true
+                        } else if !self.lease_store.is_allocated(&existing.ip)
+                            && allocator.allocate_specific(&existing.ip)
+                        {
+                            // Expired/released and free — reclaim the bit.
+                            true
+                        } else {
+                            false
+                        };
+
+                        if offer_same {
+                            let options = self.build_offer_options(&subnet);
+                            let reply = packet.build_reply(
+                                MessageType::Offer,
+                                v4,
+                                self.server_ip,
+                                options,
+                            );
+                            if !existing.is_active() {
+                                // Refresh the cached record to Offered state
+                                // so renewal/REQUEST sees a fresh binding.
+                                self.record_offer(&subnet, v4, packet).await?;
+                            }
+                            return Ok(Some(reply));
+                        }
+                    }
                 }
             }
         }
@@ -1170,6 +1200,17 @@ impl<H: HaBackend> DhcpV4Server<H> {
         }
 
         Some(existing.ip)
+    }
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl<H: HaBackend> DhcpV4Server<H> {
+    /// Test helper: directly invoke the DHCPDISCOVER handler.
+    pub async fn handle_discover_for_test(
+        &self,
+        packet: &DhcpV4Packet,
+    ) -> Result<Option<DhcpV4Packet>, Box<dyn std::error::Error + Send + Sync>> {
+        self.handle_discover(packet).await
     }
 }
 

--- a/src/lease/expiry.rs
+++ b/src/lease/expiry.rs
@@ -8,13 +8,40 @@ use super::store::LeaseStore;
 use super::types::LeaseState;
 use crate::allocator::SubnetAllocator;
 
-/// Background task that drains the expiry queue and marks leases as expired.
-/// Uses the time-indexed BTreeMap instead of full table scans.
+/// Process a single expiry tick: drain leases that expired by `now_epoch`,
+/// mark them Expired, and release each IP back to its subnet allocator.
 ///
-/// Releases the IP back to its subnet allocator so the bitmap reflects truth
-/// (issue #68). The lease record itself is preserved in the store so that the
-/// previous client can be re-offered the same IP per RFC 2131 §4.3.1 when it
-/// reappears.
+/// Returns the number of leases expired in this tick.
+///
+/// The lease record itself is preserved in the store (state -> Expired,
+/// MAC/cid index intact) so the previous client can be re-offered the same
+/// IP per RFC 2131 §4.3.1 when it reappears.
+pub fn process_expired_once(
+    store: &LeaseStore,
+    allocators: &HashMap<String, SubnetAllocator>,
+    now_epoch: u64,
+) -> usize {
+    let expired = store.drain_expired(now_epoch);
+    for ip in &expired {
+        let subnet = store.get(ip).map(|l| l.subnet.to_string());
+        store.update_state(ip, LeaseState::Expired);
+
+        match subnet {
+            Some(net) => match allocators.get(&net) {
+                Some(alloc) => {
+                    alloc.release(ip);
+                    debug!(%ip, subnet = %net, "lease expired, IP released to pool");
+                }
+                None => warn!(%ip, subnet = %net, "no allocator for expired lease subnet"),
+            },
+            None => debug!(%ip, "lease expired (no subnet record)"),
+        }
+    }
+    expired.len()
+}
+
+/// Background task that drains the expiry queue once per second and releases
+/// expired IPs back to their subnet allocators (issue #68).
 pub async fn run_expiry_task(
     store: LeaseStore,
     allocators: Arc<HashMap<String, SubnetAllocator>>,
@@ -29,24 +56,9 @@ pub async fn run_expiry_task(
             .unwrap_or_default()
             .as_secs();
 
-        let expired = store.drain_expired(now_epoch);
-        for ip in &expired {
-            let subnet = store.get(ip).map(|l| l.subnet.to_string());
-            store.update_state(ip, LeaseState::Expired);
-
-            match subnet {
-                Some(net) => match allocators.get(&net) {
-                    Some(alloc) => {
-                        alloc.release(ip);
-                        debug!(%ip, subnet = %net, "lease expired, IP released to pool");
-                    }
-                    None => warn!(%ip, subnet = %net, "no allocator for expired lease subnet"),
-                },
-                None => debug!(%ip, "lease expired (no subnet record)"),
-            }
-        }
-        if !expired.is_empty() {
-            info!(count = expired.len(), "leases expired");
+        let count = process_expired_once(&store, &allocators, now_epoch);
+        if count > 0 {
+            info!(count, "leases expired");
         }
     }
 }

--- a/src/lease/expiry.rs
+++ b/src/lease/expiry.rs
@@ -1,13 +1,24 @@
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::store::LeaseStore;
 use super::types::LeaseState;
+use crate::allocator::SubnetAllocator;
 
 /// Background task that drains the expiry queue and marks leases as expired.
 /// Uses the time-indexed BTreeMap instead of full table scans.
-pub async fn run_expiry_task(store: LeaseStore) {
+///
+/// Releases the IP back to its subnet allocator so the bitmap reflects truth
+/// (issue #68). The lease record itself is preserved in the store so that the
+/// previous client can be re-offered the same IP per RFC 2131 §4.3.1 when it
+/// reappears.
+pub async fn run_expiry_task(
+    store: LeaseStore,
+    allocators: Arc<HashMap<String, SubnetAllocator>>,
+) {
     let mut interval = tokio::time::interval(Duration::from_secs(1));
 
     loop {
@@ -20,8 +31,19 @@ pub async fn run_expiry_task(store: LeaseStore) {
 
         let expired = store.drain_expired(now_epoch);
         for ip in &expired {
+            let subnet = store.get(ip).map(|l| l.subnet.to_string());
             store.update_state(ip, LeaseState::Expired);
-            debug!(%ip, "lease expired");
+
+            match subnet {
+                Some(net) => match allocators.get(&net) {
+                    Some(alloc) => {
+                        alloc.release(ip);
+                        debug!(%ip, subnet = %net, "lease expired, IP released to pool");
+                    }
+                    None => warn!(%ip, subnet = %net, "no allocator for expired lease subnet"),
+                },
+                None => debug!(%ip, "lease expired (no subnet record)"),
+            }
         }
         if !expired.is_empty() {
             info!(count = expired.len(), "leases expired");

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,8 +130,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start lease expiry background task
     let expiry_store = lease_store.clone();
+    let expiry_allocators = allocators.clone();
     let expiry_handle = tokio::spawn(async move {
-        lease::expiry::run_expiry_task(expiry_store).await;
+        lease::expiry::run_expiry_task(expiry_store, expiry_allocators).await;
     });
 
     // Start management API if configured

--- a/tests/dhcpv4_lease_stickiness.rs
+++ b/tests/dhcpv4_lease_stickiness.rs
@@ -1,0 +1,375 @@
+//! Integration tests for lease stickiness across expiry and client_id rotation.
+//!
+//! Covers issues:
+//! - #66: client_id miss falls back to MAC
+//! - #67: re-offer the previous IP per RFC 2131 §4.3.1 even when expired
+//! - #68: expiry releases the IP back to the allocator bitmap
+//!
+//! Requires the `test-helpers` feature to access `handle_discover_for_test`.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use rdhcpd::allocator::{build_allocators, SubnetAllocator};
+use rdhcpd::config::{Config, GlobalConfig, HaConfig, SubnetConfig};
+use rdhcpd::dhcpv4::options::{DhcpOption, MessageType};
+use rdhcpd::dhcpv4::packet::DhcpV4Packet;
+use rdhcpd::dhcpv4::server::DhcpV4Server;
+use rdhcpd::dhcpv4::stats::DhcpV4Stats;
+use rdhcpd::ha::StandaloneBackend;
+use rdhcpd::lease::expiry::process_expired_once;
+use rdhcpd::lease::store::LeaseStore;
+use rdhcpd::lease::types::{Lease, LeaseState};
+use rdhcpd::ratelimit::{RateLimiter, RogueDetector};
+use rdhcpd::wal::Wal;
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+fn tempdir_path() -> String {
+    let dir = std::env::temp_dir().join(format!(
+        "rdhcpd-stickiness-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+fn make_subnet(network: &str, pool_start: &str, pool_end: &str) -> SubnetConfig {
+    SubnetConfig {
+        network: network.to_string(),
+        pool_start: Some(pool_start.to_string()),
+        pool_end: Some(pool_end.to_string()),
+        lease_time: 3600,
+        max_lease_time: None,
+        renewal_time: None,
+        rebinding_time: None,
+        preferred_time: None,
+        subnet_type: "address".to_string(),
+        delegated_length: None,
+        router: None,
+        dns: vec![],
+        ntp: vec![],
+        domain: None,
+        option: vec![],
+        ip_probe: false,
+        ip_probe_timeout_ms: None,
+        max_leases_per_mac: 1,
+        mac_allow: vec![],
+        mac_deny: vec![],
+        trusted_relays: vec![],
+        reservation: vec![],
+    }
+}
+
+fn make_global() -> GlobalConfig {
+    GlobalConfig {
+        log_level: "info".to_string(),
+        log_format: "text".to_string(),
+        lease_db: "/tmp/rdhcpd-test".to_string(),
+        workers: 1,
+        rate_limit_burst: 100,
+        rate_limit_pps: 100.0,
+        global_rate_limit_pps: 0.0,
+        rogue_threshold: 1000,
+        rogue_window_secs: 60,
+        pool_high_water: 0.9,
+        accept_relayed: true,
+        relay_rate_limit_burst: 100,
+        relay_rate_limit_pps: 100.0,
+    }
+}
+
+async fn make_server() -> (
+    DhcpV4Server<StandaloneBackend>,
+    LeaseStore,
+    Arc<HashMap<String, SubnetAllocator>>,
+) {
+    let subnet = make_subnet("10.0.0.0/24", "10.0.0.100", "10.0.0.200");
+
+    let cfg = Config {
+        global: make_global(),
+        api: None,
+        ha: HaConfig::Standalone,
+        subnet: vec![subnet],
+        ddns: None,
+    };
+
+    let dir = tempdir_path();
+    let lease_store = LeaseStore::new();
+    let allocators = Arc::new(build_allocators(&cfg, &lease_store).unwrap());
+    let wal = Arc::new(Wal::open(&dir).await.unwrap());
+    let ha = Arc::new(StandaloneBackend);
+    let server_ip = Ipv4Addr::new(10, 0, 0, 1);
+    let rate_limiter = Arc::new(RateLimiter::new(100, 100.0));
+    let relay_rate_limiter = Arc::new(RateLimiter::new(100, 100.0));
+    let rogue_detector = Arc::new(RogueDetector::new(1000, 60));
+    let stats = Arc::new(DhcpV4Stats::new());
+
+    let server = DhcpV4Server::new(
+        Arc::new(cfg),
+        lease_store.clone(),
+        Arc::clone(&allocators),
+        wal,
+        ha,
+        server_ip,
+        rate_limiter,
+        None,
+        rogue_detector,
+        relay_rate_limiter,
+        stats,
+    );
+
+    (server, lease_store, allocators)
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn seed_lease(
+    lease_store: &LeaseStore,
+    allocators: &HashMap<String, SubnetAllocator>,
+    mac: [u8; 6],
+    client_id: Option<Vec<u8>>,
+    ip: Ipv4Addr,
+    state: LeaseState,
+    expire_in_secs: i64,
+    subnet: &str,
+) {
+    let now = now_secs();
+    let expire_time = (now as i64 + expire_in_secs).max(0) as u64;
+    let lease = Lease {
+        ip: IpAddr::V4(ip),
+        mac: Some(mac),
+        client_id,
+        hostname: None,
+        lease_time: 3600,
+        state,
+        start_time: now,
+        expire_time,
+        expires_at: Instant::now() + Duration::from_secs(expire_in_secs.max(0) as u64),
+        subnet: Arc::from(subnet),
+    };
+    if matches!(state, LeaseState::Offered | LeaseState::Bound) {
+        if let Some(alloc) = allocators.get(subnet) {
+            alloc.allocate_specific(&IpAddr::V4(ip));
+        }
+    }
+    lease_store.upsert(lease);
+}
+
+fn discover_with(mac: [u8; 6], cid: Option<&[u8]>) -> DhcpV4Packet {
+    let mut packet = DhcpV4Packet::new_discover(mac);
+    if let Some(cid) = cid {
+        packet
+            .options
+            .push(DhcpOption::ClientIdentifier(cid.to_vec()));
+    }
+    packet
+}
+
+fn offered_ip(reply: &DhcpV4Packet) -> Ipv4Addr {
+    assert_eq!(reply.message_type(), Some(MessageType::Offer));
+    reply.yiaddr
+}
+
+// ---------------------------------------------------------------------------
+// Issue #68: lease expiry releases the IP back to the allocator bitmap.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn expiry_releases_ip_to_allocator() {
+    let (_server, lease_store, allocators) = make_server().await;
+    let mac: [u8; 6] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+    let ip = Ipv4Addr::new(10, 0, 0, 150);
+
+    // Seed a lease that expired 60 seconds ago.
+    seed_lease(
+        &lease_store,
+        &allocators,
+        mac,
+        None,
+        ip,
+        LeaseState::Bound,
+        -60,
+        "10.0.0.0/24",
+    );
+
+    let alloc = allocators.get("10.0.0.0/24").unwrap();
+    assert!(
+        alloc.is_allocated(&IpAddr::V4(ip)),
+        "precondition: bitmap holds the bit"
+    );
+
+    let count = process_expired_once(&lease_store, &allocators, now_secs());
+    assert_eq!(count, 1, "exactly one lease expired");
+
+    assert!(
+        !alloc.is_allocated(&IpAddr::V4(ip)),
+        "bitmap bit must be released after expiry"
+    );
+
+    let lease = lease_store.get(&IpAddr::V4(ip)).expect("record preserved");
+    assert_eq!(
+        lease.state,
+        LeaseState::Expired,
+        "lease record stays for stickiness lookup"
+    );
+    assert_eq!(
+        lease_store.get_by_mac(&mac).map(|l| l.ip),
+        Some(IpAddr::V4(ip)),
+        "MAC index intact for re-offer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #66: cid miss falls back to MAC.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn discover_falls_back_to_mac_when_client_id_changes() {
+    let (server, lease_store, allocators) = make_server().await;
+    let mac: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01];
+    let ip = Ipv4Addr::new(10, 0, 0, 150);
+    let original_cid = b"old-os-installation".to_vec();
+
+    // Bound lease with the original client_id.
+    seed_lease(
+        &lease_store,
+        &allocators,
+        mac,
+        Some(original_cid),
+        ip,
+        LeaseState::Bound,
+        3600,
+        "10.0.0.0/24",
+    );
+
+    // Same MAC, fresh client_id (e.g. OS reinstall picks a new option-61).
+    let packet = discover_with(mac, Some(b"new-os-installation"));
+    let reply = server
+        .handle_discover_for_test(&packet)
+        .await
+        .unwrap()
+        .expect("server must reply");
+
+    assert_eq!(
+        offered_ip(&reply),
+        ip,
+        "MAC fallback must recover the previous IP"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #67: re-offer the same IP after lease expiry.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn discover_reoffers_expired_ip_to_same_client() {
+    let (server, lease_store, allocators) = make_server().await;
+    let mac: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x02];
+    let ip = Ipv4Addr::new(10, 0, 0, 150);
+
+    // Seed an already-expired lease and run the expiry cycle so the bitmap
+    // reflects the post-#68 state (bit cleared, record kept).
+    seed_lease(
+        &lease_store,
+        &allocators,
+        mac,
+        None,
+        ip,
+        LeaseState::Bound,
+        -1,
+        "10.0.0.0/24",
+    );
+    process_expired_once(&lease_store, &allocators, now_secs());
+
+    let alloc = allocators.get("10.0.0.0/24").unwrap();
+    assert!(
+        !alloc.is_allocated(&IpAddr::V4(ip)),
+        "precondition: bit released by expiry"
+    );
+
+    let packet = discover_with(mac, None);
+    let reply = server
+        .handle_discover_for_test(&packet)
+        .await
+        .unwrap()
+        .expect("server must reply");
+
+    assert_eq!(
+        offered_ip(&reply),
+        ip,
+        "client should be re-offered its previous IP per RFC 2131 §4.3.1"
+    );
+    assert!(
+        alloc.is_allocated(&IpAddr::V4(ip)),
+        "re-offer must reclaim the allocator bit"
+    );
+    let lease = lease_store.get(&IpAddr::V4(ip)).unwrap();
+    assert_eq!(
+        lease.state,
+        LeaseState::Offered,
+        "record refreshed to Offered"
+    );
+}
+
+/// If the previously-held IP has been taken by another active client, fall
+/// through to fresh allocation rather than re-offering a conflicting IP.
+#[tokio::test]
+async fn discover_does_not_steal_active_lease_for_returning_client() {
+    let (server, lease_store, allocators) = make_server().await;
+    let original_mac: [u8; 6] = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x03];
+    let new_mac: [u8; 6] = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    let contested_ip = Ipv4Addr::new(10, 0, 0, 150);
+
+    // Original client's lease is expired and released by the expiry pass.
+    seed_lease(
+        &lease_store,
+        &allocators,
+        original_mac,
+        None,
+        contested_ip,
+        LeaseState::Bound,
+        -1,
+        "10.0.0.0/24",
+    );
+    process_expired_once(&lease_store, &allocators, now_secs());
+
+    // A different MAC then takes the same IP via a fresh active lease.
+    seed_lease(
+        &lease_store,
+        &allocators,
+        new_mac,
+        None,
+        contested_ip,
+        LeaseState::Bound,
+        3600,
+        "10.0.0.0/24",
+    );
+
+    // Original client returns — must not be offered the contested IP.
+    let packet = discover_with(original_mac, None);
+    let reply = server
+        .handle_discover_for_test(&packet)
+        .await
+        .unwrap()
+        .expect("server must reply");
+
+    assert_ne!(
+        offered_ip(&reply),
+        contested_ip,
+        "must not steal an active lease from another client"
+    );
+}


### PR DESCRIPTION
## Summary

- **#68** release the IP back to the allocator bitmap on lease expiry, keeping the lease record (Expired) so the previous client can still be looked up — pool no longer drifts shorter over time.
- **#66** Discover lookup falls back from `client_id` to MAC on a cid miss, so a client whose option-61 rotates between sessions (OS reinstall) recovers its previous binding.
- **#67** re-offer the previously allocated IP per RFC 2131 §4.3.1 even when the cached lease has expired, as long as the IP is in the pool and not actively held by someone else.
- Carries the prior `c58c87b` HA integration commit.

## Test plan
- [x] `cargo test --features test-helpers` — 83 tests pass, including 4 new integration tests in `tests/dhcpv4_lease_stickiness.rs` covering each fix end-to-end
- [ ] Verify on FreeBSD test VM after AiFw build picks up the new rDHCP version