### PR TITLE
HA integration + dependency refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +25,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -29,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -41,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -99,17 +105,17 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -126,9 +132,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -149,6 +155,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +175,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -183,19 +212,27 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -207,13 +244,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -243,6 +281,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -293,16 +337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,8 +355,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -333,24 +381,39 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -392,10 +455,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -407,7 +479,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
 ]
@@ -428,13 +499,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.13.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -460,10 +539,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "lock_api"
@@ -476,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matchers"
@@ -497,9 +582,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -509,9 +594,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -520,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -581,18 +666,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "zerocopy",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -620,37 +700,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rdhcpd"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "axum",
  "base64",
@@ -666,7 +740,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "socket2 0.5.10",
+ "socket2",
  "subtle",
  "thiserror",
  "tokio",
@@ -700,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -720,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -744,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -774,6 +848,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -807,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -831,11 +911,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -852,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -872,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -894,25 +974,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -926,9 +996,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -972,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -982,16 +1052,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1010,44 +1080,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -1067,13 +1135,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags",
  "bytes",
  "http",
+ "percent-encoding",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -1168,15 +1237,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1191,12 +1266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,11 +1273,54 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1301,44 +1413,109 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "serde",
  "zeroize_derive",
@@ -1346,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"
@@ -32,7 +32,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Serialization / config
 serde = { version = "1", features = ["derive"] }
-toml = "0.8"
+toml = "1"
 
 # Logging
 tracing = "0.1"
@@ -51,8 +51,8 @@ crc32fast = "1"
 byteorder = "1"
 
 # Cryptography (TSIG signing)
-sha2 = "0.10"
-hmac = "0.12"
+sha2 = "0.11"
+hmac = "0.13"
 base64 = "0.22"
 
 # Constant-time comparison (API key)
@@ -62,7 +62,7 @@ subtle = "2"
 zeroize = { version = "1", features = ["derive", "serde"] }
 
 # Random number generation (DDNS transaction IDs)
-rand = "0.9"
+rand = "0.10"
 
 # TLS for HA peer communication
 tokio-rustls = "0.26"
@@ -74,13 +74,13 @@ serde_json = "1"
 
 # REST API
 axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.7", features = ["cors"] }
 
 # Socket options (SO_REUSEPORT)
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 
 # Signal handling + lockfile fcntl (single-instance enforcement)
-nix = { version = "0.30", features = ["signal", "fs", "process"] }
+nix = { version = "0.31", features = ["signal", "fs", "process"] }
 
 # Platform-specific syscalls (FreeBSD IP_BINDANY)
 [target.'cfg(target_os = "freebsd")'.dependencies]

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -38,7 +38,7 @@ impl SubnetAllocator {
         let end_u128 = ip_to_u128(&pool_end).0;
 
         let pool_size = end_u128 - start_u128 + 1;
-        let num_words = ((pool_size + 63) / 64) as usize;
+        let num_words = pool_size.div_ceil(64) as usize;
 
         let mut bitmap = vec![0u64; num_words];
 
@@ -192,9 +192,9 @@ impl SubnetAllocator {
         }
 
         // Check subsequent full words
-        for word_idx in (start_word + 1)..num_words {
-            let word = bitmap[word_idx];
+        for (offset, &word) in bitmap[(start_word + 1)..num_words].iter().enumerate() {
             if word != u64::MAX {
+                let word_idx = start_word + 1 + offset;
                 let bit = (!word).trailing_zeros() as usize;
                 return Some(word_idx * 64 + bit);
             }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -9,7 +9,7 @@ use super::{Config, ConfigError};
 /// Rejects odd-length strings and non-hex characters.
 fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
     let s = s.trim();
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err(format!(
             "hex string must have even length, got {}",
             s.len()
@@ -153,14 +153,13 @@ fn validate_subnets(config: &Config) -> Result<(), ConfigError> {
                         i
                     )));
                 }
-                if let Some(dl) = subnet.delegated_length {
-                    if dl <= prefix_len || dl > 128 {
+                if let Some(dl) = subnet.delegated_length
+                    && (dl <= prefix_len || dl > 128) {
                         return Err(ConfigError::Validation(format!(
                             "subnet[{}]: delegated_length {} must be > prefix_len {} and <= 128",
                             i, dl, prefix_len
                         )));
                     }
-                }
             }
             other => {
                 return Err(ConfigError::Validation(format!(

--- a/src/ddns/dns.rs
+++ b/src/ddns/dns.rs
@@ -1,9 +1,10 @@
-/// Minimal DNS message builder for RFC 2136 UPDATE messages.
-/// Not a full DNS library — just enough for dynamic updates.
+//! Minimal DNS message builder for RFC 2136 UPDATE messages.
+//! Not a full DNS library — just enough for dynamic updates.
 
 /// DNS record types
 #[derive(Debug, Clone, Copy)]
 #[repr(u16)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum DnsType {
     A = 1,
     SOA = 6,
@@ -15,6 +16,7 @@ pub enum DnsType {
 #[derive(Debug, Clone, Copy)]
 #[repr(u16)]
 #[allow(dead_code)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum DnsClass {
     IN = 1,
     ANY = 255,

--- a/src/ddns/mod.rs
+++ b/src/ddns/mod.rs
@@ -286,6 +286,7 @@ async fn ddns_worker(config: Arc<DdnsConfig>, mut rx: mpsc::Receiver<DdnsRequest
 }
 
 /// Build a DNS UPDATE message (RFC 2136)
+#[allow(clippy::too_many_arguments)]
 fn build_update(
     zone: &str,
     name: &str,

--- a/src/ddns/tsig.rs
+++ b/src/ddns/tsig.rs
@@ -3,7 +3,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, Mac, digest::KeyInit};
 use sha2::Sha256;
 
 use super::dns::encode_name;

--- a/src/dhcpv4/options.rs
+++ b/src/dhcpv4/options.rs
@@ -42,9 +42,9 @@ impl MessageType {
 }
 
 /// Well-known DHCP option codes (RFC 2132).
+///
+/// Numeric constants for standard DHCP option codes.
 pub mod code {
-    //! Numeric constants for standard DHCP option codes.
-
     /// Padding byte (option 0).
     pub const PAD: u8 = 0;
     /// Subnet mask (option 1).
@@ -176,7 +176,7 @@ impl DhcpOption {
                     ))
                 }
                 code::ROUTER => {
-                    if opt_len % 4 != 0 || opt_len == 0 {
+                    if !opt_len.is_multiple_of(4) || opt_len == 0 {
                         return Err(PacketError::MalformedOption(pos));
                     }
                     let addrs = opt_data
@@ -186,7 +186,7 @@ impl DhcpOption {
                     DhcpOption::Router(addrs)
                 }
                 code::DNS => {
-                    if opt_len % 4 != 0 || opt_len == 0 {
+                    if !opt_len.is_multiple_of(4) || opt_len == 0 {
                         return Err(PacketError::MalformedOption(pos));
                     }
                     let addrs = opt_data
@@ -196,7 +196,7 @@ impl DhcpOption {
                     DhcpOption::DnsServers(addrs)
                 }
                 code::NTP => {
-                    if opt_len % 4 != 0 || opt_len == 0 {
+                    if !opt_len.is_multiple_of(4) || opt_len == 0 {
                         return Err(PacketError::MalformedOption(pos));
                     }
                     let addrs = opt_data
@@ -545,6 +545,18 @@ pub fn prefix_to_mask(prefix_len: u8) -> Ipv4Addr {
     Ipv4Addr::from(mask.to_be_bytes())
 }
 
+/// Compute the broadcast address for a network
+pub fn broadcast_addr(network: Ipv4Addr, prefix_len: u8) -> Ipv4Addr {
+    let net = u32::from_be_bytes(network.octets());
+    let mask = if prefix_len >= 32 {
+        u32::MAX
+    } else {
+        !((1u32 << (32 - prefix_len)) - 1)
+    };
+    let bcast = net | !mask;
+    Ipv4Addr::from(bcast.to_be_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -586,16 +598,4 @@ mod tests {
             needed
         );
     }
-}
-
-/// Compute the broadcast address for a network
-pub fn broadcast_addr(network: Ipv4Addr, prefix_len: u8) -> Ipv4Addr {
-    let net = u32::from_be_bytes(network.octets());
-    let mask = if prefix_len >= 32 {
-        u32::MAX
-    } else {
-        !((1u32 << (32 - prefix_len)) - 1)
-    };
-    let bcast = net | !mask;
-    Ipv4Addr::from(bcast.to_be_bytes())
 }

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -60,7 +60,7 @@ pub enum RelayDecision {
 /// Empty trusted_relays = accept any source (backwards-compatible default).
 fn relay_source_is_trusted(subnet: &SubnetInfo, source: Ipv4Addr) -> bool {
     subnet.trusted_relays.is_empty()
-        || subnet.trusted_relays.iter().any(|ip| *ip == source)
+        || subnet.trusted_relays.contains(&source)
 }
 
 /// Minimum lease time we'll grant (prevents rapid-churn DoS)
@@ -133,6 +133,7 @@ impl SubnetInfo {
 
 impl<H: HaBackend> DhcpV4Server<H> {
     /// Create a new DHCPv4 server with the given configuration, lease store, and HA backend.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
         lease_store: LeaseStore,
@@ -341,12 +342,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
             let mac = packet.mac();
 
             // Global rate limiting
-            if let Some(ref global_rl) = self.global_rate_limiter {
-                if !global_rl.check() {
+            if let Some(ref global_rl) = self.global_rate_limiter
+                && !global_rl.check() {
                     debug!(mac = %format_mac(&mac), "dropped by global rate limiter");
                     continue;
                 }
-            }
 
             // Per-client rate limiting
             if !self.rate_limiter.check(&mac) {
@@ -501,8 +501,8 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // existing lease points at a different IP than the reservation,
         // release it so the reserved IP can be offered cleanly.
         if let Some(reserved_ip) = self.find_reservation(&subnet, &mac, packet.client_id()) {
-            if let Some(ref existing) = existing_lease {
-                if existing.ip != IpAddr::V4(reserved_ip) {
+            if let Some(ref existing) = existing_lease
+                && existing.ip != IpAddr::V4(reserved_ip) {
                     info!(
                         mac = %format_mac(&mac),
                         old_ip = %existing.ip,
@@ -515,7 +515,6 @@ impl<H: HaBackend> DhcpV4Server<H> {
                         warn!(error = %e, ip = %existing.ip, "WAL log_remove failed for reservation takeover");
                     }
                 }
-            }
             let options = self.build_offer_options(&subnet);
             let reply =
                 packet.build_reply(MessageType::Offer, reserved_ip, self.server_ip, options);
@@ -528,10 +527,10 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // the pool and not held by another client. Honouring the second
         // bullet keeps a returning client on its prior IP across an expiry
         // window — a hard requirement for "OS reinstall keeps same IP".
-        if let Some(existing) = existing_lease {
-            if let IpAddr::V4(v4) = existing.ip {
-                if let Some(allocator) = self.allocators.get(&*subnet.network) {
-                    if allocator.contains(&existing.ip) {
+        if let Some(existing) = existing_lease
+            && let IpAddr::V4(v4) = existing.ip
+                && let Some(allocator) = self.allocators.get(&*subnet.network)
+                    && allocator.contains(&existing.ip) {
                         let offer_same = if existing.is_active() {
                             // Already ours in the bitmap — nothing to reclaim.
                             true
@@ -560,14 +559,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
                             return Ok(Some(reply));
                         }
                     }
-                }
-            }
-        }
 
         // Check if client is requesting a specific IP
-        if let Some(requested) = packet.requested_ip() {
-            if let Some(allocator) = self.allocators.get(&*subnet.network) {
-                if allocator.contains(&IpAddr::V4(requested))
+        if let Some(requested) = packet.requested_ip()
+            && let Some(allocator) = self.allocators.get(&*subnet.network)
+                && allocator.contains(&IpAddr::V4(requested))
                     && !self.lease_store.is_allocated(&IpAddr::V4(requested))
                     && allocator.allocate_specific(&IpAddr::V4(requested))
                 {
@@ -581,8 +577,6 @@ impl<H: HaBackend> DhcpV4Server<H> {
                     self.record_offer(&subnet, requested, packet).await?;
                     return Ok(Some(reply));
                 }
-            }
-        }
 
         // Allocate from pool
         let allocator = match self.allocators.get(&*subnet.network) {
@@ -602,13 +596,12 @@ impl<H: HaBackend> DhcpV4Server<H> {
         };
 
         // Duplicate IP detection via probe (if enabled)
-        if subnet.config.ip_probe {
-            if !probe::is_available(IpAddr::V4(ip), subnet.config.ip_probe_timeout_ms).await {
+        if subnet.config.ip_probe
+            && !probe::is_available(IpAddr::V4(ip), subnet.config.ip_probe_timeout_ms).await {
                 warn!(ip = %ip, subnet = %subnet.network, "probe detected IP in use, skipping");
                 allocator.release(&IpAddr::V4(ip));
                 return Ok(None);
             }
-        }
 
         // Pool high-water mark alerting
         if self.pool_high_water > 0.0 {
@@ -636,19 +629,17 @@ impl<H: HaBackend> DhcpV4Server<H> {
         packet: &DhcpV4Packet,
     ) -> Result<Option<DhcpV4Packet>, Box<dyn std::error::Error + Send + Sync>> {
         // If server_id is present, this is a response to an Offer
-        if let Some(server_id) = packet.server_id() {
-            if server_id != self.server_ip {
+        if let Some(server_id) = packet.server_id()
+            && server_id != self.server_ip {
                 // Not for us — if we had an offer for this client, release it
                 let mac = packet.mac();
-                if let Some(existing) = self.lease_store.get_by_mac(&mac) {
-                    if existing.state == LeaseState::Offered {
+                if let Some(existing) = self.lease_store.get_by_mac(&mac)
+                    && existing.state == LeaseState::Offered {
                         self.release_ip(&existing.ip);
                         self.lease_store.remove(&existing.ip);
                     }
-                }
                 return Ok(None);
             }
-        }
 
         // Determine the IP the client wants
         let requested_ip = if let Some(ip) = packet.requested_ip() {
@@ -686,13 +677,12 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // IP, NAK so the client falls back to INIT and re-Discovers. Without
         // this, an INIT-REBOOT request carrying a stale pool IP (e.g. after
         // unplug/replug) silently keeps the wrong address forever.
-        if let Some(reserved_ip) = self.find_reservation(&subnet, &mac, packet.client_id()) {
-            if reserved_ip != requested_ip {
+        if let Some(reserved_ip) = self.find_reservation(&subnet, &mac, packet.client_id())
+            && reserved_ip != requested_ip {
                 return Ok(Some(
                     self.build_nak(packet, "MAC has reservation for different IP"),
                 ));
             }
-        }
 
         // Cross-subnet MAC migration (issue #63): clean up any stale lease
         // this MAC holds in a different subnet before committing the new one,
@@ -703,20 +693,18 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // Check if there's an existing lease
         if let Some(existing) = self.lease_store.get(&ip_addr) {
             // Verify the lease belongs to this client
-            if let Some(existing_mac) = existing.mac {
-                if existing_mac != mac {
+            if let Some(existing_mac) = existing.mac
+                && existing_mac != mac {
                     return Ok(Some(
                         self.build_nak(packet, "IP assigned to different client"),
                     ));
                 }
-            }
         } else {
             // No existing lease — check if this is a reservation or if we need to allocate
-            if let Some(allocator) = self.allocators.get(&*subnet.network) {
-                if !allocator.is_allocated(&ip_addr) {
+            if let Some(allocator) = self.allocators.get(&*subnet.network)
+                && !allocator.is_allocated(&ip_addr) {
                     allocator.allocate_specific(&ip_addr);
                 }
-            }
         }
 
         // MAC ACL check on REQUEST too (client may have switched subnets)
@@ -732,16 +720,14 @@ impl<H: HaBackend> DhcpV4Server<H> {
 
         // Enforce lease time bounds: respect client request within [MIN, max]
         let mut lease_time = subnet.config.lease_time;
-        if let Some(requested_lt) = packet.requested_lease_time() {
-            if requested_lt >= MIN_LEASE_TIME && requested_lt < lease_time {
+        if let Some(requested_lt) = packet.requested_lease_time()
+            && requested_lt >= MIN_LEASE_TIME && requested_lt < lease_time {
                 lease_time = requested_lt;
             }
-        }
-        if let Some(max_lt) = subnet.config.max_lease_time {
-            if max_lt > 0 && lease_time > max_lt {
+        if let Some(max_lt) = subnet.config.max_lease_time
+            && max_lt > 0 && lease_time > max_lt {
                 lease_time = max_lt;
             }
-        }
         // Floor: never grant less than MIN_LEASE_TIME
         lease_time = lease_time.max(MIN_LEASE_TIME);
 
@@ -749,7 +735,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
             ip: ip_addr,
             mac: Some(mac),
             client_id: packet.client_id().map(|c| c.to_vec()),
-            hostname: packet.hostname().map(|s| Arc::from(s)),
+            hostname: packet.hostname().map(Arc::from),
             lease_time,
             state: LeaseState::Bound,
             start_time: now_epoch,
@@ -784,9 +770,9 @@ impl<H: HaBackend> DhcpV4Server<H> {
     ) -> Result<Option<DhcpV4Packet>, Box<dyn std::error::Error + Send + Sync>> {
         let ip = IpAddr::V4(packet.ciaddr);
 
-        if let Some(existing) = self.lease_store.get(&ip) {
-            if let Some(existing_mac) = existing.mac {
-                if existing_mac == packet.mac() {
+        if let Some(existing) = self.lease_store.get(&ip)
+            && let Some(existing_mac) = existing.mac
+                && existing_mac == packet.mac() {
                     self.ha.release_lease(&ip).await?;
                     self.wal.log_remove(&ip).await?;
                     self.lease_store.remove(&ip);
@@ -798,8 +784,6 @@ impl<H: HaBackend> DhcpV4Server<H> {
                         "lease released"
                     );
                 }
-            }
-        }
 
         // No reply for Release
         Ok(None)
@@ -881,8 +865,8 @@ impl<H: HaBackend> DhcpV4Server<H> {
     /// Falls through if a match isn't found at any level.
     fn select_subnet(&self, packet: &DhcpV4Packet) -> Option<SubnetInfo> {
         // Try giaddr first (relayed packets)
-        if packet.is_relayed() {
-            if let Some(s) = self.subnets.iter().find(|s| {
+        if packet.is_relayed()
+            && let Some(s) = self.subnets.iter().find(|s| {
                 ip_in_subnet(
                     &IpAddr::V4(packet.giaddr),
                     &IpAddr::V4(s.network_addr),
@@ -892,11 +876,10 @@ impl<H: HaBackend> DhcpV4Server<H> {
                 return Some(s.clone());
             }
             // giaddr didn't match any subnet — fall through
-        }
 
         // Try ciaddr (renew/rebind/inform)
-        if !packet.ciaddr.is_unspecified() {
-            if let Some(s) = self.subnets.iter().find(|s| {
+        if !packet.ciaddr.is_unspecified()
+            && let Some(s) = self.subnets.iter().find(|s| {
                 ip_in_subnet(
                     &IpAddr::V4(packet.ciaddr),
                     &IpAddr::V4(s.network_addr),
@@ -905,7 +888,6 @@ impl<H: HaBackend> DhcpV4Server<H> {
             }) {
                 return Some(s.clone());
             }
-        }
 
         // Fall back to server IP (direct connected / default subnet)
         self.subnets.iter().find(|s| {
@@ -944,7 +926,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
             ip: IpAddr::V4(ip),
             mac: Some(packet.mac()),
             client_id: packet.client_id().map(|c| c.to_vec()),
-            hostname: packet.hostname().map(|s| Arc::from(s)),
+            hostname: packet.hostname().map(Arc::from),
             lease_time: OFFER_HOLD_TIME as u32,
             state: LeaseState::Offered,
             start_time: now_epoch,
@@ -973,11 +955,10 @@ impl<H: HaBackend> DhcpV4Server<H> {
         opts.push(DhcpOption::RenewalTime(t1));
         opts.push(DhcpOption::RebindingTime(t2));
 
-        if let Some(ref router) = subnet.config.router {
-            if let Ok(r) = router.parse::<Ipv4Addr>() {
+        if let Some(ref router) = subnet.config.router
+            && let Ok(r) = router.parse::<Ipv4Addr>() {
                 opts.push(DhcpOption::Router(vec![r]));
             }
-        }
 
         let dns_addrs: Vec<Ipv4Addr> = subnet
             .config
@@ -1029,11 +1010,10 @@ impl<H: HaBackend> DhcpV4Server<H> {
         opts.push(DhcpOption::ServerIdentifier(self.server_ip));
         opts.push(DhcpOption::SubnetMask(prefix_to_mask(subnet.prefix_len)));
 
-        if let Some(ref router) = subnet.config.router {
-            if let Ok(r) = router.parse::<Ipv4Addr>() {
+        if let Some(ref router) = subnet.config.router
+            && let Ok(r) = router.parse::<Ipv4Addr>() {
                 opts.push(DhcpOption::Router(vec![r]));
             }
-        }
 
         let dns_addrs: Vec<Ipv4Addr> = subnet
             .config
@@ -1240,20 +1220,16 @@ pub(crate) fn find_reservation_for(
     client_id: Option<&[u8]>,
 ) -> Option<Ipv4Addr> {
     for res in reservations {
-        if let Some(ref res_mac) = res.mac {
-            if let Ok(parsed) = crate::config::validation::parse_mac(res_mac) {
-                if &parsed == mac {
+        if let Some(ref res_mac) = res.mac
+            && let Ok(parsed) = crate::config::validation::parse_mac(res_mac)
+                && &parsed == mac {
                     return res.ip.parse().ok();
                 }
-            }
-        }
-        if let (Some(res_cid), Some(pkt_cid)) = (&res.client_id, client_id) {
-            if let Some(parsed) = decode_hex(res_cid) {
-                if parsed == pkt_cid {
+        if let (Some(res_cid), Some(pkt_cid)) = (&res.client_id, client_id)
+            && let Some(parsed) = decode_hex(res_cid)
+                && parsed == pkt_cid {
                     return res.ip.parse().ok();
                 }
-            }
-        }
     }
     None
 }
@@ -1262,7 +1238,7 @@ pub(crate) fn find_reservation_for(
 fn decode_hex(s: &str) -> Option<Vec<u8>> {
     // Strip optional separators
     let clean: String = s.chars().filter(|c| c.is_ascii_hexdigit()).collect();
-    if clean.len() % 2 != 0 {
+    if !clean.len().is_multiple_of(2) {
         return None;
     }
     let mut bytes = Vec::with_capacity(clean.len() / 2);

--- a/src/dhcpv6/options.rs
+++ b/src/dhcpv6/options.rs
@@ -314,7 +314,7 @@ impl Dhcpv6Option {
                     })
                 }
                 code::ORO => {
-                    if opt_len % 2 != 0 {
+                    if !opt_len.is_multiple_of(2) {
                         return Err(Dhcpv6PacketError::MalformedOption(pos));
                     }
                     let codes = opt_data
@@ -350,7 +350,7 @@ impl Dhcpv6Option {
                 }
                 code::RAPID_COMMIT => Dhcpv6Option::RapidCommit,
                 code::DNS_SERVERS => {
-                    if opt_len % 16 != 0 {
+                    if !opt_len.is_multiple_of(16) {
                         return Err(Dhcpv6PacketError::MalformedOption(pos));
                     }
                     let addrs = opt_data

--- a/src/dhcpv6/server.rs
+++ b/src/dhcpv6/server.rs
@@ -55,6 +55,7 @@ struct V6SubnetInfo {
 
 impl<H: HaBackend> DhcpV6Server<H> {
     /// Create a new DHCPv6 server, parsing IPv6 subnets from the config.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Arc<Config>,
         lease_store: LeaseStore,
@@ -123,12 +124,11 @@ impl<H: HaBackend> DhcpV6Server<H> {
             }
 
             // Global rate limiting
-            if let Some(ref global_rl) = self.global_rate_limiter {
-                if !global_rl.check() {
+            if let Some(ref global_rl) = self.global_rate_limiter
+                && !global_rl.check() {
                     debug!("DHCPv6 packet dropped by global rate limiter");
                     continue;
                 }
-            }
 
             // Check if this is a relay message
             let msg_type_byte = data[0];
@@ -347,11 +347,10 @@ impl<H: HaBackend> DhcpV6Server<H> {
         msg: &Dhcpv6Message,
     ) -> Result<Option<Dhcpv6Message>, Box<dyn std::error::Error + Send + Sync>> {
         // Verify server ID matches us
-        if let Some(server_id) = msg.server_id() {
-            if server_id != self.server_duid {
+        if let Some(server_id) = msg.server_id()
+            && server_id != self.server_duid {
                 return Ok(None); // Not for us
             }
-        }
 
         let client_id = match msg.client_id() {
             Some(c) => c.to_vec(),
@@ -447,15 +446,14 @@ impl<H: HaBackend> DhcpV6Server<H> {
                 for sub_opt in &ia.options {
                     if let Dhcpv6Option::IaAddr(ia_addr) = sub_opt {
                         let ip = IpAddr::V6(ia_addr.addr);
-                        if let Some(existing) = self.lease_store.get(&ip) {
-                            if existing.client_id.as_deref() == Some(&client_id) {
+                        if let Some(existing) = self.lease_store.get(&ip)
+                            && existing.client_id.as_deref() == Some(&client_id) {
                                 self.ha.release_lease(&ip).await?;
                                 self.wal.log_remove(&ip).await?;
                                 self.lease_store.remove(&ip);
                                 self.release_ip(&ip);
                                 info!(ip = %ia_addr.addr, "DHCPv6 lease released");
                             }
-                        }
                     }
                 }
             }
@@ -646,9 +644,9 @@ impl<H: HaBackend> DhcpV6Server<H> {
         };
 
         // Check for existing lease
-        if let Some(existing) = self.lease_store.get_by_client_id(client_id) {
-            if existing.is_active() {
-                if let IpAddr::V6(v6) = existing.ip {
+        if let Some(existing) = self.lease_store.get_by_client_id(client_id)
+            && existing.is_active()
+                && let IpAddr::V6(v6) = existing.ip {
                     let lease_time = subnet.config.lease_time;
                     let preferred = subnet.config.preferred_time.unwrap_or(lease_time / 2);
                     return Ok(IaNa {
@@ -663,8 +661,6 @@ impl<H: HaBackend> DhcpV6Server<H> {
                         })],
                     });
                 }
-            }
-        }
 
         // Allocate from pool
         let allocator = match self.allocators.get(&*subnet.network) {

--- a/src/ha/active_active.rs
+++ b/src/ha/active_active.rs
@@ -49,6 +49,7 @@ struct FailoverState {
 
 impl ActiveActiveBackend {
     /// Create a new active/active backend with the given split-scope configuration.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         node_id: String,
         peer_addr: String,
@@ -186,16 +187,12 @@ impl ActiveActiveBackend {
                     };
                     drop(state);
 
-                    if let Err(e) = write_message(&mut tls_stream, &heartbeat).await {
-                        return Err(e);
-                    }
+                    write_message(&mut tls_stream, &heartbeat).await?;
                 }
                 msg = peer_rx.recv() => {
                     match msg {
                         Some(ha_msg) => {
-                            if let Err(e) = write_message(&mut tls_stream, &ha_msg).await {
-                                return Err(e);
-                            }
+                            write_message(&mut tls_stream, &ha_msg).await?;
                         }
                         None => return Ok(()), // channel closed
                     }
@@ -386,17 +383,15 @@ impl ActiveActiveBackend {
             let mut state = self.state.write().await;
 
             // Check if we should transition from CI → PartnerDown
-            if state.peer_state == PeerState::CommunicationsInterrupted {
-                if let Some(entered) = state.entered_interrupted {
-                    if entered.elapsed() >= Duration::from_secs(self.partner_down_delay as u64) {
+            if state.peer_state == PeerState::CommunicationsInterrupted
+                && let Some(entered) = state.entered_interrupted
+                    && entered.elapsed() >= Duration::from_secs(self.partner_down_delay as u64) {
                         state.peer_state = PeerState::PartnerDown;
                         warn!(
                             delay = self.partner_down_delay,
                             "partner-down delay expired, taking over full scope"
                         );
                     }
-                }
-            }
 
             // Check for stale heartbeats in Normal state
             if state.peer_state == PeerState::Normal && state.peer_reachable {

--- a/src/ha/raft.rs
+++ b/src/ha/raft.rs
@@ -328,7 +328,7 @@ impl RaftBackend {
 
         // Vote for ourselves
         let _votes = 1u32;
-        let _needed = (self.peers.len() as u32 + 1) / 2 + 1; // majority
+        let _needed = (self.peers.len() as u32).div_ceil(2) + 1; // majority
 
         // Send vote requests to all peers
         for (_peer_id, _peer_addr) in &self.peers {
@@ -442,11 +442,10 @@ impl RaftBackend {
             // Read response
             if let Some(response_msg) = read_message(&mut stream).await? {
                 // Parse response and update state
-                if let HaMessage::Heartbeat { node_id, .. } = response_msg {
-                    if let Ok(rpc_response) = serde_json::from_str::<RaftRpc>(&node_id) {
+                if let HaMessage::Heartbeat { node_id, .. } = response_msg
+                    && let Ok(rpc_response) = serde_json::from_str::<RaftRpc>(&node_id) {
                         Self::handle_rpc_response(&state, peer_id, rpc_response).await;
                     }
-                }
             }
         } else {
             // Plain TCP fallback (development only)
@@ -477,7 +476,6 @@ impl RaftBackend {
                     state.current_term = term;
                     state.role = Role::Follower;
                     state.voted_for = None;
-                    return;
                 }
                 // Vote counting is handled in the election function
             }
@@ -503,11 +501,10 @@ impl RaftBackend {
                     Self::maybe_advance_commit(&mut state);
                 } else {
                     // Decrement next_index and retry
-                    if let Some(ps) = state.peer_state.get_mut(&peer_id) {
-                        if ps.next_index > 1 {
+                    if let Some(ps) = state.peer_state.get_mut(&peer_id)
+                        && ps.next_index > 1 {
                             ps.next_index -= 1;
                         }
-                    }
                 }
             }
             _ => {}
@@ -562,10 +559,9 @@ impl RaftBackend {
 
             let state = state.clone();
             let tls_config = tls_config.clone();
-            let node_id = node_id;
 
             tokio::spawn(async move {
-                let _result = if let Some(tls) = &tls_config {
+                if let Some(tls) = &tls_config {
                     let mut stream = match tls.acceptor.accept(tcp_stream).await {
                         Ok(s) => s,
                         Err(e) => {
@@ -579,11 +575,9 @@ impl RaftBackend {
                             Ok(Some(msg)) => {
                                 if let Some(response) =
                                     Self::handle_rpc_message(&state, node_id, msg).await
-                                {
-                                    if write_message(&mut stream, &response).await.is_err() {
+                                    && write_message(&mut stream, &response).await.is_err() {
                                         break;
                                     }
-                                }
                             }
                             Ok(None) => break,
                             Err(_) => break,
@@ -596,11 +590,9 @@ impl RaftBackend {
                             Ok(Some(msg)) => {
                                 if let Some(response) =
                                     Self::handle_rpc_message(&state, node_id, msg).await
-                                {
-                                    if write_message(&mut stream, &response).await.is_err() {
+                                    && write_message(&mut stream, &response).await.is_err() {
                                         break;
                                     }
-                                }
                             }
                             Ok(None) => break,
                             Err(_) => break,
@@ -917,7 +909,7 @@ fn wrap_rpc(rpc: &RaftRpc) -> HaMessage {
 fn random_election_timeout() -> Duration {
     // 150-300ms range per Raft paper
     let base = 150;
-    let jitter = (epoch_now() % 150) as u64;
+    let jitter = epoch_now() % 150 ;
     Duration::from_millis(base + jitter)
 }
 

--- a/src/lease/store.rs
+++ b/src/lease/store.rs
@@ -30,6 +30,12 @@ struct LeaseStoreInner {
     active_count: AtomicUsize,
 }
 
+impl Default for LeaseStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LeaseStore {
     /// Create an empty lease store with no leases.
     pub fn new() -> Self {
@@ -52,16 +58,14 @@ impl LeaseStore {
         // Clean up old secondary indexes if IP already existed with different identifiers
         if let Some(old) = self.inner.leases.get(&ip) {
             was_active = old.is_active();
-            if let Some(old_mac) = old.mac {
-                if lease.mac != Some(old_mac) {
+            if let Some(old_mac) = old.mac
+                && lease.mac != Some(old_mac) {
                     self.inner.mac_index.remove(&old_mac);
                 }
-            }
-            if let Some(ref old_cid) = old.client_id {
-                if lease.client_id.as_ref() != Some(old_cid) {
+            if let Some(ref old_cid) = old.client_id
+                && lease.client_id.as_ref() != Some(old_cid) {
                     self.inner.client_id_index.remove(old_cid);
                 }
-            }
         } else {
             was_active = false;
         }
@@ -86,7 +90,7 @@ impl LeaseStore {
         // Add to expiry queue
         if is_active {
             let mut eq = self.inner.expiry_queue.lock().unwrap();
-            eq.entry(lease.expire_time).or_insert_with(Vec::new).push(ip);
+            eq.entry(lease.expire_time).or_default().push(ip);
         }
 
         self.inner.leases.insert(ip, lease);
@@ -171,11 +175,10 @@ impl LeaseStore {
             for ip in ips {
                 // Verify the lease is still active and actually expired
                 // (it may have been renewed, changing expire_time)
-                if let Some(lease) = self.inner.leases.get(&ip) {
-                    if lease.is_active() && lease.is_expired_at(now_epoch) {
+                if let Some(lease) = self.inner.leases.get(&ip)
+                    && lease.is_active() && lease.is_expired_at(now_epoch) {
                         expired.push(ip);
                     }
-                }
             }
         }
 

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -88,7 +88,7 @@ pub fn acquire_at(path: &Path) -> Result<InstanceLock, InstanceLockError> {
             let pid: i32 = buf.trim().parse().unwrap_or(0);
             return Err(InstanceLockError::AlreadyRunning(pid));
         }
-        return Err(InstanceLockError::LockFailed(errno.into()));
+        return Err(InstanceLockError::LockFailed(errno));
     }
 
     // Write our PID for diagnostics. Truncate first so a smaller PID (e.g.

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -53,24 +53,24 @@ impl WalOp {
     }
 }
 
-/// WAL entry binary layout:
-///
-/// ```text
-/// [op: 1] [ip_version: 1] [ip: 4 or 16] [state: 1]
-/// [mac_present: 1] [mac: 0 or 6]
-/// [client_id_len: 2] [client_id: 0..N]
-/// [hostname_len: 2] [hostname: 0..N]
-/// [lease_time: 4] [start_time: 8] [expire_time: 8]
-/// [subnet_len: 2] [subnet: 0..N]
-/// [crc32: 4]
-/// ```
-///
-/// For Remove/StateChange entries, only [op, ip_version, ip, state, crc32] are written.
-///
-/// **Security note**: CRC32 detects accidental corruption only. It provides no
-/// protection against deliberate tampering — an attacker with filesystem write
-/// access can craft entries with valid CRC32 checksums. Protect the WAL directory
-/// with filesystem permissions (the systemd unit restricts writes to /var/lib/rdhcpd).
+// WAL entry binary layout:
+//
+// ```text
+// [op: 1] [ip_version: 1] [ip: 4 or 16] [state: 1]
+// [mac_present: 1] [mac: 0 or 6]
+// [client_id_len: 2] [client_id: 0..N]
+// [hostname_len: 2] [hostname: 0..N]
+// [lease_time: 4] [start_time: 8] [expire_time: 8]
+// [subnet_len: 2] [subnet: 0..N]
+// [crc32: 4]
+// ```
+//
+// For Remove/StateChange entries, only [op, ip_version, ip, state, crc32] are written.
+//
+// **Security note**: CRC32 detects accidental corruption only. It provides no
+// protection against deliberate tampering — an attacker with filesystem write
+// access can craft entries with valid CRC32 checksums. Protect the WAL directory
+// with filesystem permissions (the systemd unit restricts writes to /var/lib/rdhcpd).
 
 /// Maximum allowed length for variable-length WAL fields.
 /// Prevents excessive memory allocation from corrupted/crafted WAL files.

--- a/tests/dhcpv4_lease_stickiness.rs
+++ b/tests/dhcpv4_lease_stickiness.rs
@@ -137,6 +137,7 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn seed_lease(
     lease_store: &LeaseStore,
     allocators: &HashMap<String, SubnetAllocator>,
@@ -161,11 +162,10 @@ fn seed_lease(
         expires_at: Instant::now() + Duration::from_secs(expire_in_secs.max(0) as u64),
         subnet: Arc::from(subnet),
     };
-    if matches!(state, LeaseState::Offered | LeaseState::Bound) {
-        if let Some(alloc) = allocators.get(subnet) {
+    if matches!(state, LeaseState::Offered | LeaseState::Bound)
+        && let Some(alloc) = allocators.get(subnet) {
             alloc.allocate_specific(&IpAddr::V4(ip));
         }
-    }
     lease_store.upsert(lease);
 }
 


### PR DESCRIPTION
Merges the `ha-integration` branch into `main`.

## Changes

**HA integration**
- Integration with the AiFw HA epic (active/active + Raft).

**DHCPv4 correctness fixes**
- Re-offer the previously allocated IP per RFC 2131 §4.3.1.
- Fall back to MAC lookup when `client_id` misses on Discover.
- Release IP to the allocator bitmap on lease expiry.

**Singleton**
- Fail-open on lockfile path errors, fail-closed on real conflicts.

**Dependency refresh (latest stable, no pre-release/rc)**
- Major bumps: `toml` 0.8→1, `sha2` 0.10→0.11, `hmac` 0.12→0.13, `rand` 0.9→0.10, `nix` 0.30→0.31, `socket2` 0.5→0.6, `tower-http` 0.6→0.7.
- Semver-compatible: `tokio` 1.50→1.52.3, `axum`, `rustls`, `serde_json`, `zeroize`, etc.
- Code adjustments: `tsig` imports `KeyInit` (hmac 0.13 trait reorg); `single_instance` drops a now-no-op `errno.into()`.
- Resolves all clippy warnings across the crate.

## Security
- Clears Dependabot alert #3 (GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097): `rand` is bumped to 0.10.1, the patched release.

## Testing
- `cargo clippy --all-targets --features test-helpers`: zero warnings.
- `cargo test --features test-helpers`: 83 passed, 0 failed.