### PR TITLE
Add configurable receive buffer; fix DHCPv4 send-socket reuseport bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +19,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -35,14 +29,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -126,15 +121,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -156,9 +151,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -206,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -283,12 +278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,28 +338,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -381,24 +356,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -456,9 +416,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -499,12 +459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,8 +466,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -524,11 +476,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -537,12 +489,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -561,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -666,14 +612,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "pkg-config"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
@@ -686,18 +628,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -707,12 +643,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
@@ -724,7 +660,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rdhcpd"
-version = "0.14.8"
+version = "0.15.0"
 dependencies = [
  "axum",
  "base64",
@@ -794,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -818,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -848,12 +784,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1248,12 +1178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,58 +1194,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
 
 [[package]]
 name = "windows-link"
@@ -1416,100 +1288,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.14.8"
+version = "0.15.0"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ path = "src/main.rs"
 name = "dhcpv4_relay_gates"
 required-features = ["test-helpers"]
 
+[[test]]
+name = "dhcpv4_lease_stickiness"
+required-features = ["test-helpers"]
+
 
 [dependencies]
 # Async runtime

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Key design choices behind these numbers:
 - **SO_REUSEPORT** with multiple receive workers across CPU cores
 - **Zero-allocation hot path** — `Arc<str>` for lease fields, stack buffers for packets, `MacDisplay` writer for logging
 - **Write-ahead log** with CRC32 checksums for durability without database overhead
+- **Enlarged receive buffer** (`recv_buffer_bytes`, `SO_RCVBUF`) so boot storms queue in the kernel instead of being dropped
+
+> **Tuning for very high loads:** `SO_RCVBUF` is capped by the kernel's `net.core.rmem_max`
+> (often ~208 KB by default). To let `recv_buffer_bytes` take full effect under heavy bursts,
+> raise it, e.g. `sysctl -w net.core.rmem_max=67108864`. rDHCP logs the granted buffer size on
+> startup and warns if the kernel capped it below the requested value.
 
 ## Features
 
@@ -460,6 +466,7 @@ sudo ./bench/run.sh
 | `log_format` | string | `"text"` | Log format: `text` or `json` |
 | `lease_db` | string | `"/var/lib/rdhcpd/leases"` | Directory for WAL and snapshots |
 | `workers` | int | `1` | Receive workers per protocol (DHCPv4/v6) |
+| `recv_buffer_bytes` | int | `4194304` | Receive socket buffer (`SO_RCVBUF`, 4 MiB); absorbs boot storms. Capped by `net.core.rmem_max` — raise that sysctl to grant more; `0` = OS default |
 | `rate_limit_burst` | int | `10` | Per-client max burst (packets) |
 | `rate_limit_pps` | float | `5.0` | Per-client sustained rate (packets/sec) |
 | `global_rate_limit_pps` | float | `0.0` | Global rate limit (0 = disabled) |

--- a/example-config.toml
+++ b/example-config.toml
@@ -12,6 +12,10 @@ log_level = "info"                # trace, debug, info, warn, error
 log_format = "text"               # "text" or "json"
 lease_db = "/var/lib/rdhcpd/leases"
 workers = 1                       # receive workers per protocol (DHCPv4/v6)
+recv_buffer_bytes = 4194304       # SO_RCVBUF per receive socket (4 MiB); lets bursts
+                                  # (boot storms) queue in the kernel instead of dropping.
+                                  # Capped by net.core.rmem_max — raise that sysctl to grant
+                                  # more (e.g. sysctl -w net.core.rmem_max=67108864). 0 = OS default.
 
 # --- Rate Limiting & Security ---
 rate_limit_burst = 10             # per-client burst size (packets)

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::config::Config;
 use crate::lease::store::LeaseStore;
@@ -68,9 +68,13 @@ impl SubnetAllocator {
         let hint = self.next_hint.load(Ordering::Relaxed) as usize;
 
         // Search from hint, then wrap around if needed
-        let idx = self
-            .find_free(&bitmap, hint)
-            .or_else(|| if hint > 0 { self.find_free(&bitmap, 0) } else { None })?;
+        let idx = self.find_free(&bitmap, hint).or_else(|| {
+            if hint > 0 {
+                self.find_free(&bitmap, 0)
+            } else {
+                None
+            }
+        })?;
 
         self.set_bit(&mut bitmap, idx);
         self.allocated_count.fetch_add(1, Ordering::Relaxed);

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -162,7 +162,7 @@ pub async fn delete_lease<H: HaBackend>(
     match state.lease_store.remove(&ip_addr) {
         Some(_) => {
             // Release back to allocator
-            for (_, allocator) in state.allocators.iter() {
+            for allocator in state.allocators.values() {
                 if allocator.contains(&ip_addr) {
                     allocator.release(&ip_addr);
                     break;

--- a/src/api/metrics.rs
+++ b/src/api/metrics.rs
@@ -106,14 +106,18 @@ pub async fn metrics_handler<H: HaBackend>(
     use std::sync::atomic::Ordering;
     let s = &state.dhcpv4_stats;
 
-    output.push_str("# HELP rdhcpd_dhcpv4_relayed_received_total DHCPv4 packets received with giaddr != 0\n");
+    output.push_str(
+        "# HELP rdhcpd_dhcpv4_relayed_received_total DHCPv4 packets received with giaddr != 0\n",
+    );
     output.push_str("# TYPE rdhcpd_dhcpv4_relayed_received_total counter\n");
     output.push_str(&format!(
         "rdhcpd_dhcpv4_relayed_received_total {}\n",
         s.relayed_received.load(Ordering::Relaxed)
     ));
 
-    output.push_str("# HELP rdhcpd_dhcpv4_relayed_dropped_total DHCPv4 relayed packets dropped, by reason\n");
+    output.push_str(
+        "# HELP rdhcpd_dhcpv4_relayed_dropped_total DHCPv4 relayed packets dropped, by reason\n",
+    );
     output.push_str("# TYPE rdhcpd_dhcpv4_relayed_dropped_total counter\n");
     output.push_str(&format!(
         "rdhcpd_dhcpv4_relayed_dropped_total{{reason=\"accept_relayed_disabled\"}} {}\n",
@@ -132,7 +136,10 @@ pub async fn metrics_handler<H: HaBackend>(
         s.relayed_dropped_rate_limit.load(Ordering::Relaxed)
     ));
 
-    ([(header::CONTENT_TYPE, "text/plain; version=0.0.4")], output)
+    (
+        [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+        output,
+    )
 }
 
 #[cfg(test)]
@@ -145,7 +152,8 @@ mod tests {
     fn metrics_strings_are_emitted_for_relay_counters() {
         let s = Arc::new(DhcpV4Stats::new());
         s.relayed_received.fetch_add(7, Ordering::Relaxed);
-        s.relayed_dropped_untrusted_relay.fetch_add(2, Ordering::Relaxed);
+        s.relayed_dropped_untrusted_relay
+            .fetch_add(2, Ordering::Relaxed);
 
         let mut output = String::new();
         output.push_str(&format!(
@@ -158,6 +166,8 @@ mod tests {
         ));
 
         assert!(output.contains("rdhcpd_dhcpv4_relayed_received_total 7"));
-        assert!(output.contains("rdhcpd_dhcpv4_relayed_dropped_total{reason=\"untrusted_relay\"} 2"));
+        assert!(
+            output.contains("rdhcpd_dhcpv4_relayed_dropped_total{reason=\"untrusted_relay\"} 2")
+        );
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,12 +6,12 @@ mod metrics;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use axum::Router;
 use axum::extract::State;
 use axum::http::{Request, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::Response;
 use axum::routing::{delete, get};
-use axum::Router;
 use subtle::ConstantTimeEq;
 use tokio::net::TcpListener;
 use tracing::info;
@@ -57,9 +57,7 @@ async fn auth_middleware<H: HaBackend>(
 
     // Check X-API-Key header (constant-time comparison to prevent timing attacks)
     match req.headers().get("x-api-key") {
-        Some(provided)
-            if provided.as_bytes().ct_eq(expected_key.as_bytes()).into() =>
-        {
+        Some(provided) if provided.as_bytes().ct_eq(expected_key.as_bytes()).into() => {
             Ok(next.run(req).await)
         }
         _ => Err(StatusCode::UNAUTHORIZED),
@@ -75,10 +73,7 @@ pub async fn start<H: HaBackend + 'static>(
         // Lease endpoints
         .route("/api/v1/leases", get(handlers::list_leases::<H>))
         .route("/api/v1/leases/{ip}", get(handlers::get_lease::<H>))
-        .route(
-            "/api/v1/leases/{ip}",
-            delete(handlers::delete_lease::<H>),
-        )
+        .route("/api/v1/leases/{ip}", delete(handlers::delete_lease::<H>))
         .route("/api/v1/leases/stats", get(handlers::lease_stats::<H>))
         // Subnet endpoints
         .route("/api/v1/subnets", get(handlers::list_subnets::<H>))

--- a/src/bpf.rs
+++ b/src/bpf.rs
@@ -109,7 +109,11 @@ impl BpfSender {
             "BPF sender ready"
         );
 
-        Ok(Self { fd, src_mac, src_ip })
+        Ok(Self {
+            fd,
+            src_mac,
+            src_ip,
+        })
     }
 
     /// Send a serialized DHCP payload as a raw Ethernet frame.
@@ -247,9 +251,7 @@ impl BpfSender {
     /// `BIOCSHDRCMPLT` — tell BPF we supply the full Ethernet header.
     fn set_hdrcmplt(fd: i32) -> std::io::Result<()> {
         let enable: libc::c_uint = 1;
-        let ret = unsafe {
-            libc::ioctl(fd, BIOCSHDRCMPLT, &enable as *const libc::c_uint)
-        };
+        let ret = unsafe { libc::ioctl(fd, BIOCSHDRCMPLT, &enable as *const libc::c_uint) };
         if ret < 0 {
             return Err(std::io::Error::last_os_error());
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -64,6 +64,13 @@ pub struct GlobalConfig {
     /// Per-relay-agent-source rate limit: sustained packets per second.
     #[serde(default = "default_relay_rate_limit_pps")]
     pub relay_rate_limit_pps: f64,
+    /// DHCPv4/v6 receive socket buffer size (SO_RCVBUF) in bytes. A larger
+    /// buffer absorbs boot storms (many clients powering on at once) so bursts
+    /// queue in the kernel instead of being dropped before a worker reads them.
+    /// The effective size is capped by the kernel's `net.core.rmem_max`; raise
+    /// that sysctl to grant more. Set to 0 to leave the OS default untouched.
+    #[serde(default = "default_recv_buffer_bytes")]
+    pub recv_buffer_bytes: usize,
 }
 
 /// REST API server configuration.
@@ -398,6 +405,10 @@ fn default_accept_relayed() -> bool {
 
 fn default_relay_rate_limit_burst() -> u32 {
     200
+}
+
+fn default_recv_buffer_bytes() -> usize {
+    4 * 1024 * 1024 // 4 MiB
 }
 
 fn default_relay_rate_limit_pps() -> f64 {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -10,10 +10,7 @@ use super::{Config, ConfigError};
 fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
     let s = s.trim();
     if !s.len().is_multiple_of(2) {
-        return Err(format!(
-            "hex string must have even length, got {}",
-            s.len()
-        ));
+        return Err(format!("hex string must have even length, got {}", s.len()));
     }
     let mut out = Vec::with_capacity(s.len() / 2);
     for chunk in s.as_bytes().chunks(2) {
@@ -81,10 +78,7 @@ pub fn serialize_option_override(o: &OptionOverride) -> Result<Vec<u8>, String> 
 
     if let Some(ref s) = o.string {
         if s.len() > 255 {
-            return Err(format!(
-                "string value is {} bytes, maximum is 255",
-                s.len()
-            ));
+            return Err(format!("string value is {} bytes, maximum is 255", s.len()));
         }
         if !s.bytes().all(|b| b.is_ascii_graphic() || b == b' ') {
             return Err("string value must contain only printable ASCII characters".to_string());
@@ -154,12 +148,13 @@ fn validate_subnets(config: &Config) -> Result<(), ConfigError> {
                     )));
                 }
                 if let Some(dl) = subnet.delegated_length
-                    && (dl <= prefix_len || dl > 128) {
-                        return Err(ConfigError::Validation(format!(
-                            "subnet[{}]: delegated_length {} must be > prefix_len {} and <= 128",
-                            i, dl, prefix_len
-                        )));
-                    }
+                    && (dl <= prefix_len || dl > 128)
+                {
+                    return Err(ConfigError::Validation(format!(
+                        "subnet[{}]: delegated_length {} must be > prefix_len {} and <= 128",
+                        i, dl, prefix_len
+                    )));
+                }
             }
             other => {
                 return Err(ConfigError::Validation(format!(
@@ -780,7 +775,11 @@ ip = "10.0.0.2"
         );
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("duplicate"), "expected 'duplicate' in: {}", msg);
+        assert!(
+            msg.contains("duplicate"),
+            "expected 'duplicate' in: {}",
+            msg
+        );
     }
 
     #[test]

--- a/src/ddns/mod.rs
+++ b/src/ddns/mod.rs
@@ -63,7 +63,14 @@ impl DdnsClient {
         let fqdn = self.make_fqdn(hostname);
         let ttl = self.config.ttl;
 
-        let _ = self.tx.send(DdnsRequest::Add { ip, hostname: fqdn, ttl }).await;
+        let _ = self
+            .tx
+            .send(DdnsRequest::Add {
+                ip,
+                hostname: fqdn,
+                ttl,
+            })
+            .await;
     }
 
     /// Queue a remove (forward + reverse) DNS update
@@ -73,7 +80,10 @@ impl DdnsClient {
         }
 
         let fqdn = self.make_fqdn(hostname);
-        let _ = self.tx.send(DdnsRequest::Remove { ip, hostname: fqdn }).await;
+        let _ = self
+            .tx
+            .send(DdnsRequest::Remove { ip, hostname: fqdn })
+            .await;
     }
 
     fn make_fqdn(&self, hostname: &str) -> String {
@@ -135,10 +145,7 @@ async fn ddns_worker(config: Arc<DdnsConfig>, mut rx: mpsc::Receiver<DdnsRequest
 
     let tsig_key = config.tsig_key.as_deref().and_then(|key_name| {
         let secret = config.tsig_secret.as_deref()?;
-        let algorithm = config
-            .tsig_algorithm
-            .as_deref()
-            .unwrap_or("hmac-sha256");
+        let algorithm = config.tsig_algorithm.as_deref().unwrap_or("hmac-sha256");
         Some(tsig::TsigKey {
             name: key_name.to_string(),
             algorithm: algorithm.to_string(),
@@ -382,4 +389,3 @@ fn ip_to_rdata(ip: &IpAddr) -> Vec<u8> {
         IpAddr::V6(v6) => v6.octets().to_vec(),
     }
 }
-

--- a/src/ddns/tsig.rs
+++ b/src/ddns/tsig.rs
@@ -55,10 +55,14 @@ pub fn sign_message(message: &mut Vec<u8>, key: &TsigKey, msg_id: u16) -> Result
         "hmac-sha256" => "hmac-sha256",
         "hmac-sha512" => "hmac-sha512",
         "hmac-md5" | "hmac-md5.sig-alg.reg.int" => {
-            return Err("HMAC-MD5 is deprecated and rejected — use hmac-sha256 or hmac-sha512".to_string());
+            return Err(
+                "HMAC-MD5 is deprecated and rejected — use hmac-sha256 or hmac-sha512".to_string(),
+            );
         }
         "hmac-sha1" => {
-            tracing::warn!("TSIG algorithm hmac-sha1 is deprecated — consider upgrading to hmac-sha256");
+            tracing::warn!(
+                "TSIG algorithm hmac-sha1 is deprecated — consider upgrading to hmac-sha256"
+            );
             "hmac-sha1"
         }
         other => other,
@@ -82,8 +86,7 @@ pub fn sign_message(message: &mut Vec<u8>, key: &TsigKey, msg_id: u16) -> Result
     mac_input.extend_from_slice(&0u16.to_be_bytes());
 
     // Compute HMAC-SHA256
-    let mut hmac = HmacSha256::new_from_slice(&secret)
-        .expect("HMAC can take key of any size");
+    let mut hmac = HmacSha256::new_from_slice(&secret).expect("HMAC can take key of any size");
     hmac.update(&mac_input);
     let mac = hmac.finalize().into_bytes();
 

--- a/src/dhcpv4/options.rs
+++ b/src/dhcpv4/options.rs
@@ -257,7 +257,8 @@ impl DhcpOption {
                     if opt_len != 1 {
                         return Err(PacketError::MalformedOption(pos));
                     }
-                    let mt = MessageType::from_u8(opt_data[0]).ok_or(PacketError::MalformedOption(pos))?;
+                    let mt = MessageType::from_u8(opt_data[0])
+                        .ok_or(PacketError::MalformedOption(pos))?;
                     DhcpOption::MessageType(mt)
                 }
                 code::SERVER_ID => {
@@ -271,9 +272,7 @@ impl DhcpOption {
                         opt_data[3],
                     ))
                 }
-                code::PARAMETER_REQUEST_LIST => {
-                    DhcpOption::ParameterRequestList(opt_data.to_vec())
-                }
+                code::PARAMETER_REQUEST_LIST => DhcpOption::ParameterRequestList(opt_data.to_vec()),
                 code::MAX_MESSAGE_SIZE => {
                     if opt_len != 2 {
                         return Err(PacketError::MalformedOption(pos));
@@ -563,10 +562,8 @@ mod tests {
 
     #[test]
     fn ntp_servers_roundtrip() {
-        let opt = DhcpOption::NtpServers(vec![
-            Ipv4Addr::new(10, 0, 0, 1),
-            Ipv4Addr::new(10, 0, 0, 2),
-        ]);
+        let opt =
+            DhcpOption::NtpServers(vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)]);
         let mut buf = [0u8; 16];
         let len = opt.serialize(&mut buf);
         assert_eq!(&buf[..len], &[42, 8, 10, 0, 0, 1, 10, 0, 0, 2]);

--- a/src/dhcpv4/packet.rs
+++ b/src/dhcpv4/packet.rs
@@ -327,9 +327,7 @@ impl DhcpV4Packet {
             xid: self.xid,
             secs: 0,
             flags: self.flags,
-            ciaddr: if msg_type == MessageType::Ack
-                && !self.ciaddr.is_unspecified()
-            {
+            ciaddr: if msg_type == MessageType::Ack && !self.ciaddr.is_unspecified() {
                 self.ciaddr
             } else {
                 Ipv4Addr::UNSPECIFIED
@@ -382,8 +380,8 @@ mod tests {
     fn test_rfc2131_offsets() {
         // Verify offset arithmetic
         assert_eq!(CHADDR_OFFSET, 28); // op(1)+htype(1)+hlen(1)+hops(1)+xid(4)+secs(2)+flags(2)+ciaddr(4)+yiaddr(4)+siaddr(4)+giaddr(4) = 28
-        assert_eq!(SNAME_OFFSET, 44);  // chaddr(16) + 28 = 44
-        assert_eq!(FILE_OFFSET, 108);  // sname(64) + 44 = 108
+        assert_eq!(SNAME_OFFSET, 44); // chaddr(16) + 28 = 44
+        assert_eq!(FILE_OFFSET, 108); // sname(64) + 44 = 108
         assert_eq!(COOKIE_OFFSET, 236); // file(128) + 108 = 236
         assert_eq!(OPTIONS_OFFSET, 240); // cookie(4) + 236 = 240
     }
@@ -425,8 +423,8 @@ mod tests {
 
         // Verify options start after cookie
         assert_eq!(buf[240], 53); // option 53 = message type
-        assert_eq!(buf[241], 1);  // length 1
-        assert_eq!(buf[242], 1);  // DISCOVER
+        assert_eq!(buf[241], 1); // length 1
+        assert_eq!(buf[242], 1); // DISCOVER
 
         // Parse it back
         let parsed = DhcpV4Packet::parse(&buf[..len]).unwrap();

--- a/src/dhcpv4/server.rs
+++ b/src/dhcpv4/server.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::net::UdpSocket;
 use tracing::{debug, error, info, warn};
 
-use super::options::{broadcast_addr, prefix_to_mask, DhcpOption, MessageType};
+use super::options::{DhcpOption, MessageType, broadcast_addr, prefix_to_mask};
 use super::packet::{DhcpV4Packet, MAX_PACKET_SIZE};
 use crate::allocator::SubnetAllocator;
 use crate::config::validation::{ip_in_subnet, parse_cidr, parse_mac};
@@ -59,8 +59,7 @@ pub enum RelayDecision {
 /// Returns true if `source` is an acceptable relay agent for `subnet`.
 /// Empty trusted_relays = accept any source (backwards-compatible default).
 fn relay_source_is_trusted(subnet: &SubnetInfo, source: Ipv4Addr) -> bool {
-    subnet.trusted_relays.is_empty()
-        || subnet.trusted_relays.contains(&source)
+    subnet.trusted_relays.is_empty() || subnet.trusted_relays.contains(&source)
 }
 
 /// Minimum lease time we'll grant (prevents rapid-churn DoS)
@@ -219,11 +218,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
 
     /// Classify a received DHCPv4 packet against the relay security gates.
     /// Increments the appropriate `stats` counter as a side-effect.
-    pub fn classify_relayed(
-        &self,
-        packet: &DhcpV4Packet,
-        src_addr: SocketAddr,
-    ) -> RelayDecision {
+    pub fn classify_relayed(&self, packet: &DhcpV4Packet, src_addr: SocketAddr) -> RelayDecision {
         if !packet.is_relayed() {
             return RelayDecision::NotRelayed;
         }
@@ -231,35 +226,51 @@ impl<H: HaBackend> DhcpV4Server<H> {
         self.stats.relayed_received.fetch_add(1, Ordering::Relaxed);
 
         if !self.config_accept_relayed {
-            self.stats.relayed_dropped_disabled.fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .relayed_dropped_disabled
+                .fetch_add(1, Ordering::Relaxed);
             return RelayDecision::DroppedDisabled;
         }
         if crate::config::validation::is_bogon_giaddr(packet.giaddr) {
-            self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .relayed_dropped_bad_giaddr
+                .fetch_add(1, Ordering::Relaxed);
             return RelayDecision::DroppedBadGiaddr;
         }
         let relay_subnet = match self.subnets.iter().find(|s| {
-            ip_in_subnet(&IpAddr::V4(packet.giaddr), &IpAddr::V4(s.network_addr), s.prefix_len)
+            ip_in_subnet(
+                &IpAddr::V4(packet.giaddr),
+                &IpAddr::V4(s.network_addr),
+                s.prefix_len,
+            )
         }) {
             Some(s) => s,
             None => {
-                self.stats.relayed_dropped_bad_giaddr.fetch_add(1, Ordering::Relaxed);
+                self.stats
+                    .relayed_dropped_bad_giaddr
+                    .fetch_add(1, Ordering::Relaxed);
                 return RelayDecision::DroppedBadGiaddr;
             }
         };
         let source_ip = match src_addr.ip() {
             IpAddr::V4(v4) => v4,
             _ => {
-                self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
+                self.stats
+                    .relayed_dropped_untrusted_relay
+                    .fetch_add(1, Ordering::Relaxed);
                 return RelayDecision::DroppedUntrustedRelay;
             }
         };
         if !relay_source_is_trusted(relay_subnet, source_ip) {
-            self.stats.relayed_dropped_untrusted_relay.fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .relayed_dropped_untrusted_relay
+                .fetch_add(1, Ordering::Relaxed);
             return RelayDecision::DroppedUntrustedRelay;
         }
         if !self.relay_rate_limiter.check(&source_ip.octets()) {
-            self.stats.relayed_dropped_rate_limit.fetch_add(1, Ordering::Relaxed);
+            self.stats
+                .relayed_dropped_rate_limit
+                .fetch_add(1, Ordering::Relaxed);
             return RelayDecision::DroppedRateLimit;
         }
         RelayDecision::Accept
@@ -343,10 +354,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
 
             // Global rate limiting
             if let Some(ref global_rl) = self.global_rate_limiter
-                && !global_rl.check() {
-                    debug!(mac = %format_mac(&mac), "dropped by global rate limiter");
-                    continue;
-                }
+                && !global_rl.check()
+            {
+                debug!(mac = %format_mac(&mac), "dropped by global rate limiter");
+                continue;
+            }
 
             // Per-client rate limiting
             if !self.rate_limiter.check(&mac) {
@@ -386,13 +398,8 @@ impl<H: HaBackend> DhcpV4Server<H> {
                     let mut send_buf = [0u8; MAX_PACKET_SIZE];
                     let send_len = reply.serialize(&mut send_buf);
 
-                    let send_result = self.send_reply(
-                        &sender,
-                        &send_buf[..send_len],
-                        &packet,
-                        &reply,
-                        src_addr,
-                    );
+                    let send_result =
+                        self.send_reply(&sender, &send_buf[..send_len], &packet, &reply, src_addr);
 
                     if let Err(e) = send_result {
                         error!(error = %e, "failed to send reply");
@@ -431,8 +438,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
         match sender {
             #[cfg(target_os = "freebsd")]
             DhcpSender::Bpf(bpf) => {
-                let (dest_mac, dest_ip) =
-                    self.bpf_reply_destination(request, reply, src_addr);
+                let (dest_mac, dest_ip) = self.bpf_reply_destination(request, reply, src_addr);
                 bpf.send_dhcp(payload, dest_mac, dest_ip)?;
                 Ok(())
             }
@@ -502,19 +508,20 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // release it so the reserved IP can be offered cleanly.
         if let Some(reserved_ip) = self.find_reservation(&subnet, &mac, packet.client_id()) {
             if let Some(ref existing) = existing_lease
-                && existing.ip != IpAddr::V4(reserved_ip) {
-                    info!(
-                        mac = %format_mac(&mac),
-                        old_ip = %existing.ip,
-                        reserved_ip = %reserved_ip,
-                        "releasing non-reserved lease in favour of reservation"
-                    );
-                    self.lease_store.remove(&existing.ip);
-                    self.release_ip(&existing.ip);
-                    if let Err(e) = self.wal.log_remove(&existing.ip).await {
-                        warn!(error = %e, ip = %existing.ip, "WAL log_remove failed for reservation takeover");
-                    }
+                && existing.ip != IpAddr::V4(reserved_ip)
+            {
+                info!(
+                    mac = %format_mac(&mac),
+                    old_ip = %existing.ip,
+                    reserved_ip = %reserved_ip,
+                    "releasing non-reserved lease in favour of reservation"
+                );
+                self.lease_store.remove(&existing.ip);
+                self.release_ip(&existing.ip);
+                if let Err(e) = self.wal.log_remove(&existing.ip).await {
+                    warn!(error = %e, ip = %existing.ip, "WAL log_remove failed for reservation takeover");
                 }
+            }
             let options = self.build_offer_options(&subnet);
             let reply =
                 packet.build_reply(MessageType::Offer, reserved_ip, self.server_ip, options);
@@ -529,54 +536,45 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // window — a hard requirement for "OS reinstall keeps same IP".
         if let Some(existing) = existing_lease
             && let IpAddr::V4(v4) = existing.ip
-                && let Some(allocator) = self.allocators.get(&*subnet.network)
-                    && allocator.contains(&existing.ip) {
-                        let offer_same = if existing.is_active() {
-                            // Already ours in the bitmap — nothing to reclaim.
-                            true
-                        } else if !self.lease_store.is_allocated(&existing.ip)
-                            && allocator.allocate_specific(&existing.ip)
-                        {
-                            // Expired/released and free — reclaim the bit.
-                            true
-                        } else {
-                            false
-                        };
+            && let Some(allocator) = self.allocators.get(&*subnet.network)
+            && allocator.contains(&existing.ip)
+        {
+            let offer_same = if existing.is_active() {
+                // Already ours in the bitmap — nothing to reclaim.
+                true
+            } else if !self.lease_store.is_allocated(&existing.ip)
+                && allocator.allocate_specific(&existing.ip)
+            {
+                // Expired/released and free — reclaim the bit.
+                true
+            } else {
+                false
+            };
 
-                        if offer_same {
-                            let options = self.build_offer_options(&subnet);
-                            let reply = packet.build_reply(
-                                MessageType::Offer,
-                                v4,
-                                self.server_ip,
-                                options,
-                            );
-                            if !existing.is_active() {
-                                // Refresh the cached record to Offered state
-                                // so renewal/REQUEST sees a fresh binding.
-                                self.record_offer(&subnet, v4, packet).await?;
-                            }
-                            return Ok(Some(reply));
-                        }
-                    }
+            if offer_same {
+                let options = self.build_offer_options(&subnet);
+                let reply = packet.build_reply(MessageType::Offer, v4, self.server_ip, options);
+                if !existing.is_active() {
+                    // Refresh the cached record to Offered state
+                    // so renewal/REQUEST sees a fresh binding.
+                    self.record_offer(&subnet, v4, packet).await?;
+                }
+                return Ok(Some(reply));
+            }
+        }
 
         // Check if client is requesting a specific IP
         if let Some(requested) = packet.requested_ip()
             && let Some(allocator) = self.allocators.get(&*subnet.network)
-                && allocator.contains(&IpAddr::V4(requested))
-                    && !self.lease_store.is_allocated(&IpAddr::V4(requested))
-                    && allocator.allocate_specific(&IpAddr::V4(requested))
-                {
-                    let options = self.build_offer_options(&subnet);
-                    let reply = packet.build_reply(
-                        MessageType::Offer,
-                        requested,
-                        self.server_ip,
-                        options,
-                    );
-                    self.record_offer(&subnet, requested, packet).await?;
-                    return Ok(Some(reply));
-                }
+            && allocator.contains(&IpAddr::V4(requested))
+            && !self.lease_store.is_allocated(&IpAddr::V4(requested))
+            && allocator.allocate_specific(&IpAddr::V4(requested))
+        {
+            let options = self.build_offer_options(&subnet);
+            let reply = packet.build_reply(MessageType::Offer, requested, self.server_ip, options);
+            self.record_offer(&subnet, requested, packet).await?;
+            return Ok(Some(reply));
+        }
 
         // Allocate from pool
         let allocator = match self.allocators.get(&*subnet.network) {
@@ -597,11 +595,12 @@ impl<H: HaBackend> DhcpV4Server<H> {
 
         // Duplicate IP detection via probe (if enabled)
         if subnet.config.ip_probe
-            && !probe::is_available(IpAddr::V4(ip), subnet.config.ip_probe_timeout_ms).await {
-                warn!(ip = %ip, subnet = %subnet.network, "probe detected IP in use, skipping");
-                allocator.release(&IpAddr::V4(ip));
-                return Ok(None);
-            }
+            && !probe::is_available(IpAddr::V4(ip), subnet.config.ip_probe_timeout_ms).await
+        {
+            warn!(ip = %ip, subnet = %subnet.network, "probe detected IP in use, skipping");
+            allocator.release(&IpAddr::V4(ip));
+            return Ok(None);
+        }
 
         // Pool high-water mark alerting
         if self.pool_high_water > 0.0 {
@@ -630,16 +629,18 @@ impl<H: HaBackend> DhcpV4Server<H> {
     ) -> Result<Option<DhcpV4Packet>, Box<dyn std::error::Error + Send + Sync>> {
         // If server_id is present, this is a response to an Offer
         if let Some(server_id) = packet.server_id()
-            && server_id != self.server_ip {
-                // Not for us — if we had an offer for this client, release it
-                let mac = packet.mac();
-                if let Some(existing) = self.lease_store.get_by_mac(&mac)
-                    && existing.state == LeaseState::Offered {
-                        self.release_ip(&existing.ip);
-                        self.lease_store.remove(&existing.ip);
-                    }
-                return Ok(None);
+            && server_id != self.server_ip
+        {
+            // Not for us — if we had an offer for this client, release it
+            let mac = packet.mac();
+            if let Some(existing) = self.lease_store.get_by_mac(&mac)
+                && existing.state == LeaseState::Offered
+            {
+                self.release_ip(&existing.ip);
+                self.lease_store.remove(&existing.ip);
             }
+            return Ok(None);
+        }
 
         // Determine the IP the client wants
         let requested_ip = if let Some(ip) = packet.requested_ip() {
@@ -665,9 +666,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
             &IpAddr::V4(subnet.network_addr),
             subnet.prefix_len,
         ) {
-            return Ok(Some(
-                self.build_nak(packet, "requested IP not in subnet"),
-            ));
+            return Ok(Some(self.build_nak(packet, "requested IP not in subnet")));
         }
 
         let mac = packet.mac();
@@ -678,11 +677,12 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // this, an INIT-REBOOT request carrying a stale pool IP (e.g. after
         // unplug/replug) silently keeps the wrong address forever.
         if let Some(reserved_ip) = self.find_reservation(&subnet, &mac, packet.client_id())
-            && reserved_ip != requested_ip {
-                return Ok(Some(
-                    self.build_nak(packet, "MAC has reservation for different IP"),
-                ));
-            }
+            && reserved_ip != requested_ip
+        {
+            return Ok(Some(
+                self.build_nak(packet, "MAC has reservation for different IP"),
+            ));
+        }
 
         // Cross-subnet MAC migration (issue #63): clean up any stale lease
         // this MAC holds in a different subnet before committing the new one,
@@ -694,17 +694,19 @@ impl<H: HaBackend> DhcpV4Server<H> {
         if let Some(existing) = self.lease_store.get(&ip_addr) {
             // Verify the lease belongs to this client
             if let Some(existing_mac) = existing.mac
-                && existing_mac != mac {
-                    return Ok(Some(
-                        self.build_nak(packet, "IP assigned to different client"),
-                    ));
-                }
+                && existing_mac != mac
+            {
+                return Ok(Some(
+                    self.build_nak(packet, "IP assigned to different client"),
+                ));
+            }
         } else {
             // No existing lease — check if this is a reservation or if we need to allocate
             if let Some(allocator) = self.allocators.get(&*subnet.network)
-                && !allocator.is_allocated(&ip_addr) {
-                    allocator.allocate_specific(&ip_addr);
-                }
+                && !allocator.is_allocated(&ip_addr)
+            {
+                allocator.allocate_specific(&ip_addr);
+            }
         }
 
         // MAC ACL check on REQUEST too (client may have switched subnets)
@@ -721,13 +723,17 @@ impl<H: HaBackend> DhcpV4Server<H> {
         // Enforce lease time bounds: respect client request within [MIN, max]
         let mut lease_time = subnet.config.lease_time;
         if let Some(requested_lt) = packet.requested_lease_time()
-            && requested_lt >= MIN_LEASE_TIME && requested_lt < lease_time {
-                lease_time = requested_lt;
-            }
+            && requested_lt >= MIN_LEASE_TIME
+            && requested_lt < lease_time
+        {
+            lease_time = requested_lt;
+        }
         if let Some(max_lt) = subnet.config.max_lease_time
-            && max_lt > 0 && lease_time > max_lt {
-                lease_time = max_lt;
-            }
+            && max_lt > 0
+            && lease_time > max_lt
+        {
+            lease_time = max_lt;
+        }
         // Floor: never grant less than MIN_LEASE_TIME
         lease_time = lease_time.max(MIN_LEASE_TIME);
 
@@ -757,8 +763,7 @@ impl<H: HaBackend> DhcpV4Server<H> {
         );
 
         let options = self.build_ack_options(&subnet);
-        let reply =
-            packet.build_reply(MessageType::Ack, requested_ip, self.server_ip, options);
+        let reply = packet.build_reply(MessageType::Ack, requested_ip, self.server_ip, options);
 
         Ok(Some(reply))
     }
@@ -772,18 +777,19 @@ impl<H: HaBackend> DhcpV4Server<H> {
 
         if let Some(existing) = self.lease_store.get(&ip)
             && let Some(existing_mac) = existing.mac
-                && existing_mac == packet.mac() {
-                    self.ha.release_lease(&ip).await?;
-                    self.wal.log_remove(&ip).await?;
-                    self.lease_store.remove(&ip);
-                    self.release_ip(&ip);
+            && existing_mac == packet.mac()
+        {
+            self.ha.release_lease(&ip).await?;
+            self.wal.log_remove(&ip).await?;
+            self.lease_store.remove(&ip);
+            self.release_ip(&ip);
 
-                    info!(
-                        ip = %packet.ciaddr,
-                        mac = %format_mac(&packet.mac()),
-                        "lease released"
-                    );
-                }
+            info!(
+                ip = %packet.ciaddr,
+                mac = %format_mac(&packet.mac()),
+                "lease released"
+            );
+        }
 
         // No reply for Release
         Ok(None)
@@ -804,7 +810,9 @@ impl<H: HaBackend> DhcpV4Server<H> {
             );
 
             // Determine subnet for this IP
-            let subnet_name: Arc<str> = self.subnets.iter()
+            let subnet_name: Arc<str> = self
+                .subnets
+                .iter()
                 .find(|s| ip_in_subnet(&ip, &IpAddr::V4(s.network_addr), s.prefix_len))
                 .map(|s| Arc::clone(&s.network))
                 .unwrap_or_else(|| Arc::from("unknown"));
@@ -872,10 +880,11 @@ impl<H: HaBackend> DhcpV4Server<H> {
                     &IpAddr::V4(s.network_addr),
                     s.prefix_len,
                 )
-            }) {
-                return Some(s.clone());
-            }
-            // giaddr didn't match any subnet — fall through
+            })
+        {
+            return Some(s.clone());
+        }
+        // giaddr didn't match any subnet — fall through
 
         // Try ciaddr (renew/rebind/inform)
         if !packet.ciaddr.is_unspecified()
@@ -885,18 +894,22 @@ impl<H: HaBackend> DhcpV4Server<H> {
                     &IpAddr::V4(s.network_addr),
                     s.prefix_len,
                 )
-            }) {
-                return Some(s.clone());
-            }
+            })
+        {
+            return Some(s.clone());
+        }
 
         // Fall back to server IP (direct connected / default subnet)
-        self.subnets.iter().find(|s| {
-            ip_in_subnet(
-                &IpAddr::V4(self.server_ip),
-                &IpAddr::V4(s.network_addr),
-                s.prefix_len,
-            )
-        }).cloned()
+        self.subnets
+            .iter()
+            .find(|s| {
+                ip_in_subnet(
+                    &IpAddr::V4(self.server_ip),
+                    &IpAddr::V4(s.network_addr),
+                    s.prefix_len,
+                )
+            })
+            .cloned()
     }
 
     /// Find a reservation for this client (instance wrapper around the pure
@@ -948,17 +961,22 @@ impl<H: HaBackend> DhcpV4Server<H> {
         opts.push(DhcpOption::SubnetMask(prefix_to_mask(subnet.prefix_len)));
 
         // T1 = configurable or 50% lease time, T2 = configurable or 87.5% lease time
-        let t1 = subnet.config.renewal_time
+        let t1 = subnet
+            .config
+            .renewal_time
             .unwrap_or(subnet.config.lease_time / 2);
-        let t2 = subnet.config.rebinding_time
+        let t2 = subnet
+            .config
+            .rebinding_time
             .unwrap_or((subnet.config.lease_time as u64 * 7 / 8) as u32);
         opts.push(DhcpOption::RenewalTime(t1));
         opts.push(DhcpOption::RebindingTime(t2));
 
         if let Some(ref router) = subnet.config.router
-            && let Ok(r) = router.parse::<Ipv4Addr>() {
-                opts.push(DhcpOption::Router(vec![r]));
-            }
+            && let Ok(r) = router.parse::<Ipv4Addr>()
+        {
+            opts.push(DhcpOption::Router(vec![r]));
+        }
 
         let dns_addrs: Vec<Ipv4Addr> = subnet
             .config
@@ -1011,9 +1029,10 @@ impl<H: HaBackend> DhcpV4Server<H> {
         opts.push(DhcpOption::SubnetMask(prefix_to_mask(subnet.prefix_len)));
 
         if let Some(ref router) = subnet.config.router
-            && let Ok(r) = router.parse::<Ipv4Addr>() {
-                opts.push(DhcpOption::Router(vec![r]));
-            }
+            && let Ok(r) = router.parse::<Ipv4Addr>()
+        {
+            opts.push(DhcpOption::Router(vec![r]));
+        }
 
         let dns_addrs: Vec<Ipv4Addr> = subnet
             .config
@@ -1222,14 +1241,16 @@ pub(crate) fn find_reservation_for(
     for res in reservations {
         if let Some(ref res_mac) = res.mac
             && let Ok(parsed) = crate::config::validation::parse_mac(res_mac)
-                && &parsed == mac {
-                    return res.ip.parse().ok();
-                }
+            && &parsed == mac
+        {
+            return res.ip.parse().ok();
+        }
         if let (Some(res_cid), Some(pkt_cid)) = (&res.client_id, client_id)
             && let Some(parsed) = decode_hex(res_cid)
-                && parsed == pkt_cid {
-                    return res.ip.parse().ok();
-                }
+            && parsed == pkt_cid
+        {
+            return res.ip.parse().ok();
+        }
     }
     None
 }
@@ -1305,7 +1326,10 @@ mod relay_gate_tests {
     fn empty_trusted_relays_allows_any_source() {
         let subnet = make_subnet_info("10.0.0.0", 24, vec![]);
         assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 5)));
-        assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(192, 168, 1, 1)));
+        assert!(relay_source_is_trusted(
+            &subnet,
+            Ipv4Addr::new(192, 168, 1, 1)
+        ));
     }
 
     #[test]
@@ -1314,7 +1338,10 @@ mod relay_gate_tests {
         let subnet = make_subnet_info("10.0.0.0", 24, trusted);
         assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 5)));
         assert!(relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 6)));
-        assert!(!relay_source_is_trusted(&subnet, Ipv4Addr::new(10, 0, 0, 7)));
+        assert!(!relay_source_is_trusted(
+            &subnet,
+            Ipv4Addr::new(10, 0, 0, 7)
+        ));
     }
 }
 
@@ -1354,10 +1381,17 @@ mod subnet_info_tests {
     fn trusted_relays_are_parsed_into_subnet_info() {
         let cfg = make_subnet(
             "10.0.0.0/24",
-            vec!["10.0.0.5".to_string(), "invalid".to_string(), "10.0.0.6".to_string()],
+            vec![
+                "10.0.0.5".to_string(),
+                "invalid".to_string(),
+                "10.0.0.6".to_string(),
+            ],
         );
         let parsed = SubnetInfo::parse_trusted_relays(&cfg);
-        assert_eq!(parsed, vec![Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 6)]);
+        assert_eq!(
+            parsed,
+            vec![Ipv4Addr::new(10, 0, 0, 5), Ipv4Addr::new(10, 0, 0, 6)]
+        );
     }
 
     #[test]
@@ -1435,7 +1469,11 @@ mod reservation_tests {
         ];
         let mac: [u8; 6] = [0xbc, 0x24, 0x11, 0xa7, 0x4a, 0x2b];
         assert_eq!(
-            find_reservation_for(&reservations, &mac, Some(&[0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66])),
+            find_reservation_for(
+                &reservations,
+                &mac,
+                Some(&[0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66])
+            ),
             Some(Ipv4Addr::new(172, 29, 11, 19)),
         );
     }
@@ -1471,7 +1509,10 @@ mod reservation_tests {
         let requested = Ipv4Addr::new(172, 29, 11, 20);
         let reserved = find_reservation_for(&reservations, &mac, None);
         assert_eq!(reserved, Some(Ipv4Addr::new(172, 29, 11, 19)));
-        assert!(reserved != Some(requested), "would NAK since reservation ≠ requested");
+        assert!(
+            reserved != Some(requested),
+            "would NAK since reservation ≠ requested"
+        );
     }
 
     #[test]
@@ -1515,8 +1556,7 @@ mod custom_options_tests {
             u32_val: None,
             hex: None,
         };
-        let bytes =
-            crate::config::validation::serialize_option_override(&o).unwrap();
+        let bytes = crate::config::validation::serialize_option_override(&o).unwrap();
         assert_eq!(bytes, vec![10, 0, 0, 5]);
 
         // Wrap in Unknown and verify wire format

--- a/src/dhcpv4/stats.rs
+++ b/src/dhcpv4/stats.rs
@@ -22,7 +22,6 @@ impl DhcpV4Stats {
     pub fn new() -> Self {
         Self::default()
     }
-
 }
 
 #[cfg(test)]

--- a/src/dhcpv6/options.rs
+++ b/src/dhcpv6/options.rs
@@ -201,24 +201,12 @@ impl Dhcpv6Option {
                     if opt_len < 12 {
                         return Err(Dhcpv6PacketError::MalformedOption(pos));
                     }
-                    let iaid = u32::from_be_bytes([
-                        opt_data[0],
-                        opt_data[1],
-                        opt_data[2],
-                        opt_data[3],
-                    ]);
-                    let t1 = u32::from_be_bytes([
-                        opt_data[4],
-                        opt_data[5],
-                        opt_data[6],
-                        opt_data[7],
-                    ]);
-                    let t2 = u32::from_be_bytes([
-                        opt_data[8],
-                        opt_data[9],
-                        opt_data[10],
-                        opt_data[11],
-                    ]);
+                    let iaid =
+                        u32::from_be_bytes([opt_data[0], opt_data[1], opt_data[2], opt_data[3]]);
+                    let t1 =
+                        u32::from_be_bytes([opt_data[4], opt_data[5], opt_data[6], opt_data[7]]);
+                    let t2 =
+                        u32::from_be_bytes([opt_data[8], opt_data[9], opt_data[10], opt_data[11]]);
                     let sub_opts = Self::parse_all_inner(&opt_data[12..], depth + 1)?;
                     Dhcpv6Option::IaNa(IaNa {
                         iaid,
@@ -258,24 +246,12 @@ impl Dhcpv6Option {
                     if opt_len < 12 {
                         return Err(Dhcpv6PacketError::MalformedOption(pos));
                     }
-                    let iaid = u32::from_be_bytes([
-                        opt_data[0],
-                        opt_data[1],
-                        opt_data[2],
-                        opt_data[3],
-                    ]);
-                    let t1 = u32::from_be_bytes([
-                        opt_data[4],
-                        opt_data[5],
-                        opt_data[6],
-                        opt_data[7],
-                    ]);
-                    let t2 = u32::from_be_bytes([
-                        opt_data[8],
-                        opt_data[9],
-                        opt_data[10],
-                        opt_data[11],
-                    ]);
+                    let iaid =
+                        u32::from_be_bytes([opt_data[0], opt_data[1], opt_data[2], opt_data[3]]);
+                    let t1 =
+                        u32::from_be_bytes([opt_data[4], opt_data[5], opt_data[6], opt_data[7]]);
+                    let t2 =
+                        u32::from_be_bytes([opt_data[8], opt_data[9], opt_data[10], opt_data[11]]);
                     let sub_opts = Self::parse_all_inner(&opt_data[12..], depth + 1)?;
                     Dhcpv6Option::IaPd(IaPd {
                         iaid,
@@ -288,18 +264,10 @@ impl Dhcpv6Option {
                     if opt_len < 25 {
                         return Err(Dhcpv6PacketError::MalformedOption(pos));
                     }
-                    let preferred = u32::from_be_bytes([
-                        opt_data[0],
-                        opt_data[1],
-                        opt_data[2],
-                        opt_data[3],
-                    ]);
-                    let valid = u32::from_be_bytes([
-                        opt_data[4],
-                        opt_data[5],
-                        opt_data[6],
-                        opt_data[7],
-                    ]);
+                    let preferred =
+                        u32::from_be_bytes([opt_data[0], opt_data[1], opt_data[2], opt_data[3]]);
+                    let valid =
+                        u32::from_be_bytes([opt_data[4], opt_data[5], opt_data[6], opt_data[7]]);
                     let prefix_len = opt_data[8];
                     let mut prefix_bytes = [0u8; 16];
                     prefix_bytes.copy_from_slice(&opt_data[9..25]);
@@ -426,7 +394,10 @@ impl Dhcpv6Option {
             Dhcpv6Option::RapidCommit => 4,
             Dhcpv6Option::DnsServers(addrs) => 4 + addrs.len() * 16,
             Dhcpv6Option::DomainList(domains) => {
-                let encoded_len: usize = domains.iter().map(|d| d.split('.').map(|l| 1 + l.len()).sum::<usize>() + 1).sum();
+                let encoded_len: usize = domains
+                    .iter()
+                    .map(|d| d.split('.').map(|l| 1 + l.len()).sum::<usize>() + 1)
+                    .sum();
                 4 + encoded_len
             }
             Dhcpv6Option::RelayMessage(data)

--- a/src/dhcpv6/packet.rs
+++ b/src/dhcpv6/packet.rs
@@ -112,8 +112,8 @@ impl Dhcpv6Message {
             return Err(Dhcpv6PacketError::TooShort(data.len()));
         }
 
-        let msg_type =
-            Dhcpv6MessageType::from_u8(data[0]).ok_or(Dhcpv6PacketError::BadMessageType(data[0]))?;
+        let msg_type = Dhcpv6MessageType::from_u8(data[0])
+            .ok_or(Dhcpv6PacketError::BadMessageType(data[0]))?;
 
         if msg_type.is_relay() {
             return Err(Dhcpv6PacketError::BadMessageType(data[0]));
@@ -178,8 +178,8 @@ impl Dhcpv6RelayMessage {
             return Err(Dhcpv6PacketError::TooShort(data.len()));
         }
 
-        let msg_type =
-            Dhcpv6MessageType::from_u8(data[0]).ok_or(Dhcpv6PacketError::BadMessageType(data[0]))?;
+        let msg_type = Dhcpv6MessageType::from_u8(data[0])
+            .ok_or(Dhcpv6PacketError::BadMessageType(data[0]))?;
 
         if !msg_type.is_relay() {
             return Err(Dhcpv6PacketError::BadMessageType(data[0]));

--- a/src/dhcpv6/server.rs
+++ b/src/dhcpv6/server.rs
@@ -6,9 +6,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::net::UdpSocket;
 use tracing::{debug, error, info, warn};
 
-use super::options::{
-    Dhcpv6Option, IaAddr, IaNa, IaPd, IaPrefix, StatusCode,
-};
+use super::options::{Dhcpv6Option, IaAddr, IaNa, IaPd, IaPrefix, StatusCode};
 use super::packet::{Dhcpv6Message, Dhcpv6MessageType, Dhcpv6RelayMessage};
 use crate::allocator::SubnetAllocator;
 use crate::config::validation::{ip_in_subnet, parse_cidr};
@@ -125,10 +123,11 @@ impl<H: HaBackend> DhcpV6Server<H> {
 
             // Global rate limiting
             if let Some(ref global_rl) = self.global_rate_limiter
-                && !global_rl.check() {
-                    debug!("DHCPv6 packet dropped by global rate limiter");
-                    continue;
-                }
+                && !global_rl.check()
+            {
+                debug!("DHCPv6 packet dropped by global rate limiter");
+                continue;
+            }
 
             // Check if this is a relay message
             let msg_type_byte = data[0];
@@ -168,7 +167,10 @@ impl<H: HaBackend> DhcpV6Server<H> {
                 debug!("DHCPv6 packet dropped by per-client rate limiter");
                 return Ok(None);
             }
-            let label = client_id.iter().map(|b| format!("{:02x}", b)).collect::<String>();
+            let label = client_id
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>();
             if !self.rogue_detector.record(client_id, &label) {
                 debug!("DHCPv6 packet dropped by rogue detector");
                 return Ok(None);
@@ -215,7 +217,10 @@ impl<H: HaBackend> DhcpV6Server<H> {
 
         // RFC 8415 §5.2: drop if hop count exceeds 32
         if relay_msg.hop_count > 32 {
-            warn!(hop_count = relay_msg.hop_count, "dropping relay with excessive hop count");
+            warn!(
+                hop_count = relay_msg.hop_count,
+                "dropping relay with excessive hop count"
+            );
             return Ok(None);
         }
 
@@ -237,9 +242,7 @@ impl<H: HaBackend> DhcpV6Server<H> {
         );
 
         let reply = match client_msg.msg_type {
-            Dhcpv6MessageType::Solicit => {
-                self.handle_solicit(&client_msg, Some(link_addr)).await?
-            }
+            Dhcpv6MessageType::Solicit => self.handle_solicit(&client_msg, Some(link_addr)).await?,
             Dhcpv6MessageType::Request => self.handle_request(&client_msg).await?,
             Dhcpv6MessageType::Renew => self.handle_renew(&client_msg).await?,
             Dhcpv6MessageType::Rebind => self.handle_rebind(&client_msg).await?,
@@ -266,7 +269,8 @@ impl<H: HaBackend> DhcpV6Server<H> {
                     link_address: relay_msg.link_address,
                     peer_address: relay_msg.peer_address,
                     options: {
-                        let mut opts = vec![Dhcpv6Option::RelayMessage(inner_buf[..inner_len].to_vec())];
+                        let mut opts =
+                            vec![Dhcpv6Option::RelayMessage(inner_buf[..inner_len].to_vec())];
                         if let Some(iid) = relay_msg.interface_id() {
                             opts.push(Dhcpv6Option::InterfaceId(iid.to_vec()));
                         }
@@ -324,9 +328,7 @@ impl<H: HaBackend> DhcpV6Server<H> {
         // Process each IA_PD in the request
         for opt in &msg.options {
             if let Dhcpv6Option::IaPd(ia) = opt {
-                let ia_reply = self
-                    .allocate_ia_pd(ia, &client_id, rapid_commit)
-                    .await?;
+                let ia_reply = self.allocate_ia_pd(ia, &client_id, rapid_commit).await?;
                 reply_options.push(Dhcpv6Option::IaPd(ia_reply));
             }
         }
@@ -348,9 +350,10 @@ impl<H: HaBackend> DhcpV6Server<H> {
     ) -> Result<Option<Dhcpv6Message>, Box<dyn std::error::Error + Send + Sync>> {
         // Verify server ID matches us
         if let Some(server_id) = msg.server_id()
-            && server_id != self.server_duid {
-                return Ok(None); // Not for us
-            }
+            && server_id != self.server_duid
+        {
+            return Ok(None); // Not for us
+        }
 
         let client_id = match msg.client_id() {
             Some(c) => c.to_vec(),
@@ -447,13 +450,14 @@ impl<H: HaBackend> DhcpV6Server<H> {
                     if let Dhcpv6Option::IaAddr(ia_addr) = sub_opt {
                         let ip = IpAddr::V6(ia_addr.addr);
                         if let Some(existing) = self.lease_store.get(&ip)
-                            && existing.client_id.as_deref() == Some(&client_id) {
-                                self.ha.release_lease(&ip).await?;
-                                self.wal.log_remove(&ip).await?;
-                                self.lease_store.remove(&ip);
-                                self.release_ip(&ip);
-                                info!(ip = %ia_addr.addr, "DHCPv6 lease released");
-                            }
+                            && existing.client_id.as_deref() == Some(&client_id)
+                        {
+                            self.ha.release_lease(&ip).await?;
+                            self.wal.log_remove(&ip).await?;
+                            self.lease_store.remove(&ip);
+                            self.release_ip(&ip);
+                            info!(ip = %ia_addr.addr, "DHCPv6 lease released");
+                        }
                     }
                 }
             }
@@ -489,8 +493,13 @@ impl<H: HaBackend> DhcpV6Server<H> {
                         warn!(ip = %ia_addr.addr, "DHCPv6 address declined (possible conflict)");
                         // Mark as declined — keep allocated so it's not reassigned
                         let ip = IpAddr::V6(ia_addr.addr);
-                        let subnet_name: Arc<str> = self.subnets.iter()
-                            .find(|s| !s.is_pd && ip_in_subnet(&ip, &IpAddr::V6(s.network_addr), s.prefix_len))
+                        let subnet_name: Arc<str> = self
+                            .subnets
+                            .iter()
+                            .find(|s| {
+                                !s.is_pd
+                                    && ip_in_subnet(&ip, &IpAddr::V6(s.network_addr), s.prefix_len)
+                            })
                             .map(|s| s.network.clone())
                             .unwrap_or_else(|| Arc::from("unknown"));
                         let now_epoch = epoch_now();
@@ -617,11 +626,7 @@ impl<H: HaBackend> DhcpV6Server<H> {
                     return false;
                 }
                 if let Some(la) = link_addr {
-                    ip_in_subnet(
-                        &IpAddr::V6(la),
-                        &IpAddr::V6(s.network_addr),
-                        s.prefix_len,
-                    )
+                    ip_in_subnet(&IpAddr::V6(la), &IpAddr::V6(s.network_addr), s.prefix_len)
                 } else {
                     true // Direct client, use first v6 address subnet
                 }
@@ -646,21 +651,22 @@ impl<H: HaBackend> DhcpV6Server<H> {
         // Check for existing lease
         if let Some(existing) = self.lease_store.get_by_client_id(client_id)
             && existing.is_active()
-                && let IpAddr::V6(v6) = existing.ip {
-                    let lease_time = subnet.config.lease_time;
-                    let preferred = subnet.config.preferred_time.unwrap_or(lease_time / 2);
-                    return Ok(IaNa {
-                        iaid: ia.iaid,
-                        t1: lease_time / 2,
-                        t2: (lease_time as u64 * 7 / 8) as u32,
-                        options: vec![Dhcpv6Option::IaAddr(IaAddr {
-                            addr: v6,
-                            preferred_lifetime: preferred,
-                            valid_lifetime: lease_time,
-                            options: vec![],
-                        })],
-                    });
-                }
+            && let IpAddr::V6(v6) = existing.ip
+        {
+            let lease_time = subnet.config.lease_time;
+            let preferred = subnet.config.preferred_time.unwrap_or(lease_time / 2);
+            return Ok(IaNa {
+                iaid: ia.iaid,
+                t1: lease_time / 2,
+                t2: (lease_time as u64 * 7 / 8) as u32,
+                options: vec![Dhcpv6Option::IaAddr(IaAddr {
+                    addr: v6,
+                    preferred_lifetime: preferred,
+                    valid_lifetime: lease_time,
+                    options: vec![],
+                })],
+            });
+        }
 
         // Allocate from pool
         let allocator = match self.allocators.get(&*subnet.network) {
@@ -847,8 +853,7 @@ impl<H: HaBackend> DhcpV6Server<H> {
 
                 // Find subnet for this address
                 let subnet = self.subnets.iter().find(|s| {
-                    !s.is_pd
-                        && ip_in_subnet(&ip, &IpAddr::V6(s.network_addr), s.prefix_len)
+                    !s.is_pd && ip_in_subnet(&ip, &IpAddr::V6(s.network_addr), s.prefix_len)
                 });
 
                 let subnet = match subnet {
@@ -1001,20 +1006,11 @@ impl<H: HaBackend> DhcpV6Server<H> {
     }
 
     /// Add DNS-related options to a reply
-    fn add_dns_options(
-        &self,
-        options: &mut Vec<Dhcpv6Option>,
-        link_addr: Option<Ipv6Addr>,
-    ) {
+    fn add_dns_options(&self, options: &mut Vec<Dhcpv6Option>, link_addr: Option<Ipv6Addr>) {
         // Find first matching v6 subnet for DNS config
         let subnet = if let Some(la) = link_addr {
             self.subnets.iter().find(|s| {
-                !s.is_pd
-                    && ip_in_subnet(
-                        &IpAddr::V6(la),
-                        &IpAddr::V6(s.network_addr),
-                        s.prefix_len,
-                    )
+                !s.is_pd && ip_in_subnet(&IpAddr::V6(la), &IpAddr::V6(s.network_addr), s.prefix_len)
             })
         } else {
             self.subnets.iter().find(|s| !s.is_pd)
@@ -1039,7 +1035,7 @@ impl<H: HaBackend> DhcpV6Server<H> {
 
     /// Release an IP back to the pool allocator
     fn release_ip(&self, ip: &IpAddr) {
-        for (_, allocator) in self.allocators.iter() {
+        for allocator in self.allocators.values() {
             if allocator.contains(ip) {
                 allocator.release(ip);
                 return;

--- a/src/ha/active_active.rs
+++ b/src/ha/active_active.rs
@@ -1,13 +1,13 @@
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tokio::net::TcpListener;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, error, info, warn};
 
-use super::peer::{read_message, write_message, TlsConfig};
+use super::peer::{TlsConfig, read_message, write_message};
 use super::protocol::{HaMessage, PeerState};
 use super::{HaBackend, HaError, HaStatus};
 use crate::lease::store::LeaseStore;
@@ -316,8 +316,7 @@ impl ActiveActiveBackend {
                         state: lease_state,
                         start_time,
                         expire_time,
-                        expires_at: std::time::Instant::now()
-                            + Duration::from_secs(remaining),
+                        expires_at: std::time::Instant::now() + Duration::from_secs(remaining),
                         subnet: Arc::from(subnet.as_str()),
                     };
                     self.lease_store.upsert(lease);
@@ -354,8 +353,7 @@ impl ActiveActiveBackend {
                             state: lease_state,
                             start_time: entry.start_time,
                             expire_time: entry.expire_time,
-                            expires_at: std::time::Instant::now()
-                                + Duration::from_secs(remaining),
+                            expires_at: std::time::Instant::now() + Duration::from_secs(remaining),
                             subnet: Arc::from(entry.subnet.as_str()),
                         };
                         self.lease_store.upsert(lease);
@@ -363,10 +361,7 @@ impl ActiveActiveBackend {
                 }
             }
             HaMessage::StateTransition {
-                node_id,
-                from,
-                to,
-                ..
+                node_id, from, to, ..
             } => {
                 info!(peer = %node_id, from = %from, to = %to, "peer state transition");
             }
@@ -385,13 +380,14 @@ impl ActiveActiveBackend {
             // Check if we should transition from CI → PartnerDown
             if state.peer_state == PeerState::CommunicationsInterrupted
                 && let Some(entered) = state.entered_interrupted
-                    && entered.elapsed() >= Duration::from_secs(self.partner_down_delay as u64) {
-                        state.peer_state = PeerState::PartnerDown;
-                        warn!(
-                            delay = self.partner_down_delay,
-                            "partner-down delay expired, taking over full scope"
-                        );
-                    }
+                && entered.elapsed() >= Duration::from_secs(self.partner_down_delay as u64)
+            {
+                state.peer_state = PeerState::PartnerDown;
+                warn!(
+                    delay = self.partner_down_delay,
+                    "partner-down delay expired, taking over full scope"
+                );
+            }
 
             // Check for stale heartbeats in Normal state
             if state.peer_state == PeerState::Normal && state.peer_reachable {
@@ -475,9 +471,7 @@ impl HaBackend for ActiveActiveBackend {
     }
 
     async fn release_lease(&self, ip: &IpAddr) -> Result<(), HaError> {
-        let msg = HaMessage::LeaseRelease {
-            ip: ip.to_string(),
-        };
+        let msg = HaMessage::LeaseRelease { ip: ip.to_string() };
         let _ = self.peer_tx.try_send(msg);
         Ok(())
     }

--- a/src/ha/peer.rs
+++ b/src/ha/peer.rs
@@ -25,8 +25,8 @@ impl TlsConfig {
         // Load server cert chain
         let cert_file = std::fs::File::open(cert_path)?;
         let mut cert_reader = std::io::BufReader::new(cert_file);
-        let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut cert_reader)
-            .collect::<Result<Vec<_>, _>>()?;
+        let certs: Vec<CertificateDer<'static>> =
+            rustls_pemfile::certs(&mut cert_reader).collect::<Result<Vec<_>, _>>()?;
 
         // Load private key
         let key_file = std::fs::File::open(key_path)?;
@@ -37,8 +37,8 @@ impl TlsConfig {
         // Load CA cert for peer verification
         let ca_file = std::fs::File::open(ca_cert_path)?;
         let mut ca_reader = std::io::BufReader::new(ca_file);
-        let ca_certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut ca_reader)
-            .collect::<Result<Vec<_>, _>>()?;
+        let ca_certs: Vec<CertificateDer<'static>> =
+            rustls_pemfile::certs(&mut ca_reader).collect::<Result<Vec<_>, _>>()?;
 
         let mut root_store = rustls::RootCertStore::empty();
         for cert in &ca_certs {

--- a/src/ha/protocol.rs
+++ b/src/ha/protocol.rs
@@ -1,6 +1,4 @@
-
 use serde::{Deserialize, Serialize};
-
 
 /// HA wire protocol messages exchanged between peers.
 /// Framed as: [4-byte big-endian length][JSON payload]

--- a/src/ha/raft.rs
+++ b/src/ha/raft.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, error, info};
 
-use super::peer::{read_message, write_message, TlsConfig};
+use super::peer::{TlsConfig, read_message, write_message};
 use super::protocol::HaMessage;
 use super::{HaBackend, HaError, HaStatus};
 use crate::lease::store::LeaseStore;
@@ -130,7 +130,10 @@ pub struct RaftBackend {
     /// Lease store to apply committed entries
     lease_store: LeaseStore,
     /// Channel to propose new entries
-    propose_tx: mpsc::Sender<(RaftCommand, tokio::sync::oneshot::Sender<Result<(), HaError>>)>,
+    propose_tx: mpsc::Sender<(
+        RaftCommand,
+        tokio::sync::oneshot::Sender<Result<(), HaError>>,
+    )>,
     /// TLS config
     tls_config: Option<Arc<TlsConfig>>,
     /// Listen address for Raft RPCs
@@ -313,11 +316,7 @@ impl RaftBackend {
         let last_log_index = state.last_log_index();
         let last_log_term = state.last_log_term();
 
-        info!(
-            node = self.node_id,
-            term,
-            "starting election"
-        );
+        info!(node = self.node_id, term, "starting election");
 
         let vote_request = RaftRpc::VoteRequest {
             term,
@@ -334,7 +333,10 @@ impl RaftBackend {
         for (_peer_id, _peer_addr) in &self.peers {
             let _msg_json = serde_json::to_vec(&vote_request).unwrap_or_default();
             let _ha_msg = HaMessage::Heartbeat {
-                node_id: format!("raft:{}", serde_json::to_string(&vote_request).unwrap_or_default()),
+                node_id: format!(
+                    "raft:{}",
+                    serde_json::to_string(&vote_request).unwrap_or_default()
+                ),
                 state: super::protocol::PeerState::Normal,
                 active_leases: 0,
                 timestamp: 0,
@@ -403,9 +405,14 @@ impl RaftBackend {
             let peer_id = *peer_id;
 
             tokio::spawn(async move {
-                if let Err(e) =
-                    Self::send_rpc(&peer_addr, &rpc, tls_config.as_deref(), state_clone, peer_id)
-                        .await
+                if let Err(e) = Self::send_rpc(
+                    &peer_addr,
+                    &rpc,
+                    tls_config.as_deref(),
+                    state_clone,
+                    peer_id,
+                )
+                .await
                 {
                     debug!(peer = peer_id, error = %e, "failed to send AppendEntries");
                 }
@@ -443,9 +450,10 @@ impl RaftBackend {
             if let Some(response_msg) = read_message(&mut stream).await? {
                 // Parse response and update state
                 if let HaMessage::Heartbeat { node_id, .. } = response_msg
-                    && let Ok(rpc_response) = serde_json::from_str::<RaftRpc>(&node_id) {
-                        Self::handle_rpc_response(&state, peer_id, rpc_response).await;
-                    }
+                    && let Ok(rpc_response) = serde_json::from_str::<RaftRpc>(&node_id)
+                {
+                    Self::handle_rpc_response(&state, peer_id, rpc_response).await;
+                }
             }
         } else {
             // Plain TCP fallback (development only)
@@ -463,15 +471,14 @@ impl RaftBackend {
     }
 
     /// Handle an RPC response from a peer
-    async fn handle_rpc_response(
-        state: &Arc<RwLock<RaftState>>,
-        peer_id: u64,
-        response: RaftRpc,
-    ) {
+    async fn handle_rpc_response(state: &Arc<RwLock<RaftState>>, peer_id: u64, response: RaftRpc) {
         let mut state = state.write().await;
 
         match response {
-            RaftRpc::VoteResponse { term, vote_granted: _ } => {
+            RaftRpc::VoteResponse {
+                term,
+                vote_granted: _,
+            } => {
                 if term > state.current_term {
                     state.current_term = term;
                     state.role = Role::Follower;
@@ -502,9 +509,10 @@ impl RaftBackend {
                 } else {
                     // Decrement next_index and retry
                     if let Some(ps) = state.peer_state.get_mut(&peer_id)
-                        && ps.next_index > 1 {
-                            ps.next_index -= 1;
-                        }
+                        && ps.next_index > 1
+                    {
+                        ps.next_index -= 1;
+                    }
                 }
             }
             _ => {}
@@ -575,9 +583,10 @@ impl RaftBackend {
                             Ok(Some(msg)) => {
                                 if let Some(response) =
                                     Self::handle_rpc_message(&state, node_id, msg).await
-                                    && write_message(&mut stream, &response).await.is_err() {
-                                        break;
-                                    }
+                                    && write_message(&mut stream, &response).await.is_err()
+                                {
+                                    break;
+                                }
                             }
                             Ok(None) => break,
                             Err(_) => break,
@@ -590,9 +599,10 @@ impl RaftBackend {
                             Ok(Some(msg)) => {
                                 if let Some(response) =
                                     Self::handle_rpc_message(&state, node_id, msg).await
-                                    && write_message(&mut stream, &response).await.is_err() {
-                                        break;
-                                    }
+                                    && write_message(&mut stream, &response).await.is_err()
+                                {
+                                    break;
+                                }
                             }
                             Ok(None) => break,
                             Err(_) => break,
@@ -786,8 +796,7 @@ impl RaftBackend {
                     } => {
                         if let Ok(ip_addr) = ip.parse::<IpAddr>() {
                             let mac_bytes = mac.as_ref().and_then(|m| parse_mac_str(m));
-                            let ls =
-                                LeaseState::from_u8(lease_state).unwrap_or(LeaseState::Bound);
+                            let ls = LeaseState::from_u8(lease_state).unwrap_or(LeaseState::Bound);
                             let now = epoch_now();
                             let remaining = expire_time.saturating_sub(now);
 
@@ -851,9 +860,7 @@ impl HaBackend for RaftBackend {
     }
 
     async fn release_lease(&self, ip: &IpAddr) -> Result<(), HaError> {
-        let cmd = RaftCommand::LeaseRemove {
-            ip: ip.to_string(),
-        };
+        let cmd = RaftCommand::LeaseRemove { ip: ip.to_string() };
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.propose_tx
@@ -909,7 +916,7 @@ fn wrap_rpc(rpc: &RaftRpc) -> HaMessage {
 fn random_election_timeout() -> Duration {
     // 150-300ms range per Raft paper
     let base = 150;
-    let jitter = epoch_now() % 150 ;
+    let jitter = epoch_now() % 150;
     Duration::from_millis(base + jitter)
 }
 

--- a/src/lease/expiry.rs
+++ b/src/lease/expiry.rs
@@ -42,10 +42,7 @@ pub fn process_expired_once(
 
 /// Background task that drains the expiry queue once per second and releases
 /// expired IPs back to their subnet allocators (issue #68).
-pub async fn run_expiry_task(
-    store: LeaseStore,
-    allocators: Arc<HashMap<String, SubnetAllocator>>,
-) {
+pub async fn run_expiry_task(store: LeaseStore, allocators: Arc<HashMap<String, SubnetAllocator>>) {
     let mut interval = tokio::time::interval(Duration::from_secs(1));
 
     loop {

--- a/src/lease/store.rs
+++ b/src/lease/store.rs
@@ -59,13 +59,15 @@ impl LeaseStore {
         if let Some(old) = self.inner.leases.get(&ip) {
             was_active = old.is_active();
             if let Some(old_mac) = old.mac
-                && lease.mac != Some(old_mac) {
-                    self.inner.mac_index.remove(&old_mac);
-                }
+                && lease.mac != Some(old_mac)
+            {
+                self.inner.mac_index.remove(&old_mac);
+            }
             if let Some(ref old_cid) = old.client_id
-                && lease.client_id.as_ref() != Some(old_cid) {
-                    self.inner.client_id_index.remove(old_cid);
-                }
+                && lease.client_id.as_ref() != Some(old_cid)
+            {
+                self.inner.client_id_index.remove(old_cid);
+            }
         } else {
             was_active = false;
         }
@@ -176,9 +178,11 @@ impl LeaseStore {
                 // Verify the lease is still active and actually expired
                 // (it may have been renewed, changing expire_time)
                 if let Some(lease) = self.inner.leases.get(&ip)
-                    && lease.is_active() && lease.is_expired_at(now_epoch) {
-                        expired.push(ip);
-                    }
+                    && lease.is_active()
+                    && lease.is_expired_at(now_epoch)
+                {
+                    expired.push(ip);
+                }
             }
         }
 
@@ -198,10 +202,7 @@ impl LeaseStore {
     /// Check if an IP is currently leased (Offered or Bound) — no clone.
     #[inline]
     pub fn is_allocated(&self, ip: &IpAddr) -> bool {
-        self.inner
-            .leases
-            .get(ip)
-            .is_some_and(|r| r.is_active())
+        self.inner.leases.get(ip).is_some_and(|r| r.is_active())
     }
 
     /// Count all active leases held by a given MAC address across all subnets.
@@ -209,9 +210,7 @@ impl LeaseStore {
         self.inner
             .leases
             .iter()
-            .filter(|r| {
-                r.value().is_active() && r.value().mac.as_ref() == Some(mac)
-            })
+            .filter(|r| r.value().is_active() && r.value().mac.as_ref() == Some(mac))
             .count()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Number of receive workers per protocol
     let worker_count = config.global.workers;
 
+    // Receive socket buffer size (SO_RCVBUF) — absorbs boot storms without drops
+    let recv_buffer_bytes = config.global.recv_buffer_bytes;
+
     // DHCPv4 port — default 67
     // RDHCPD_V4_PORT: override for testing/benchmarking only (not for production)
     let dhcpv4_port: u16 = std::env::var("RDHCPD_V4_PORT")
@@ -209,8 +212,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // On FreeBSD we also capture the interface name and MAC address so
         // we can open a BPF device for raw-frame replies.
         // -----------------------------------------------------------------
-        #[cfg(not(target_os = "freebsd"))]
-        let send_bind_ip = Ipv4Addr::UNSPECIFIED;
         #[cfg(target_os = "freebsd")]
         let mut send_bind_ip = Ipv4Addr::UNSPECIFIED;
         #[cfg(target_os = "freebsd")]
@@ -331,10 +332,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        #[cfg(not(target_os = "freebsd"))]
-        let sender: Arc<DhcpSender> = Arc::new(DhcpSender::Udp(
-            build_udp_send_socket(send_bind_ip, dhcpv4_port)?,
-        ));
+        // On non-FreeBSD each worker replies from its own receive socket (see the
+        // worker loop below), so there is no separate shared send socket. A dedicated
+        // 0.0.0.0:67 send socket would join the recv SO_REUSEPORT group and could be
+        // handed inbound broadcast requests that it never reads — silently dropping
+        // them depending on the kernel's reuseport hash.
 
         // -----------------------------------------------------------------
         // Spawn receive workers
@@ -351,13 +353,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut sockets: Vec<Arc<UdpSocket>> = Vec::new();
             #[cfg(target_os = "freebsd")]
             {
-                sockets.push(build_recv_socket(&bcast_bind, true)?);
-                sockets.push(build_recv_socket(&any_bind, false)?);
+                sockets.push(build_recv_socket(&bcast_bind, true, recv_buffer_bytes)?);
+                sockets.push(build_recv_socket(&any_bind, false, recv_buffer_bytes)?);
             }
             #[cfg(not(target_os = "freebsd"))]
             {
                 let _ = &bcast_bind; // unused on non-FreeBSD
-                sockets.push(build_recv_socket(&any_bind, false)?);
+                sockets.push(build_recv_socket(&any_bind, false, recv_buffer_bytes)?);
             }
 
             let dhcpv4_server = Arc::new(DhcpV4Server::new(
@@ -376,7 +378,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             for (sock_idx, recv_socket) in sockets.into_iter().enumerate() {
                 let server = dhcpv4_server.clone();
+                // FreeBSD replies via the shared BPF/UDP sender; elsewhere reply from
+                // this worker's own recv socket (source port 67, broadcast-capable) so
+                // no extra socket competes for inbound traffic in the SO_REUSEPORT group.
+                #[cfg(target_os = "freebsd")]
                 let worker_sender = sender.clone();
+                #[cfg(not(target_os = "freebsd"))]
+                let worker_sender = Arc::new(DhcpSender::Udp(recv_socket.clone()));
                 dhcpv4_handles.push(tokio::spawn(async move {
                     if let Err(e) = server.run(recv_socket, worker_sender).await {
                         error!(error = %e, worker = worker_id, sock_idx, "DHCPv4 server error");
@@ -405,6 +413,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|e| format!("failed to create DHCPv6 socket: {}", e))?;
             sock.set_reuse_port(true)?;
             sock.set_nonblocking(true)?;
+            apply_recv_buffer(&sock, recv_buffer_bytes, "[::]:547");
             sock.bind(&"[::]:547".parse::<std::net::SocketAddr>().unwrap().into())
                 .map_err(|e| format!("failed to bind DHCPv6 port 547: {} (try running as root)", e))?;
             let dhcpv6_socket = Arc::new(UdpSocket::from_std(sock.into())?);
@@ -486,6 +495,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Enlarge a socket's receive buffer (`SO_RCVBUF`) so bursts — e.g. a boot storm
+/// where many clients power on at once — queue in the kernel instead of being
+/// dropped before a worker can read them. The effective size is capped by the
+/// kernel's `net.core.rmem_max`; if the kernel grants far less than requested we
+/// warn so the operator can raise that sysctl. `bytes == 0` leaves the OS default.
+fn apply_recv_buffer(sock: &socket2::Socket, bytes: usize, label: &str) {
+    if bytes == 0 {
+        return;
+    }
+    if let Err(e) = sock.set_recv_buffer_size(bytes) {
+        warn!(error = %e, socket = label, "failed to set SO_RCVBUF");
+        return;
+    }
+    match sock.recv_buffer_size() {
+        // Linux reports back ~2x the requested value; only warn on a clear shortfall.
+        Ok(actual) if actual < bytes => warn!(
+            socket = label,
+            requested = bytes,
+            granted = actual,
+            "SO_RCVBUF capped below requested — raise net.core.rmem_max to avoid receive drops under load"
+        ),
+        Ok(actual) => info!(
+            socket = label,
+            requested = bytes,
+            granted = actual,
+            "receive buffer enlarged"
+        ),
+        Err(e) => warn!(error = %e, socket = label, "could not read back SO_RCVBUF"),
+    }
+}
+
 /// Create a UDP receive socket for DHCPv4.
 ///
 /// On FreeBSD, `freebsd_bindany` enables IP_BINDANY so the socket can bind to
@@ -494,6 +534,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn build_recv_socket(
     bind_addr: &str,
     freebsd_bindany: bool,
+    recv_buffer_bytes: usize,
 ) -> Result<Arc<UdpSocket>, Box<dyn std::error::Error>> {
     let sock = socket2::Socket::new(
         socket2::Domain::IPV4,
@@ -504,6 +545,7 @@ fn build_recv_socket(
     sock.set_reuse_port(true)?;
     sock.set_broadcast(true)?;
     sock.set_nonblocking(true)?;
+    apply_recv_buffer(&sock, recv_buffer_bytes, bind_addr);
 
     #[cfg(target_os = "freebsd")]
     if freebsd_bindany {
@@ -529,7 +571,9 @@ fn build_recv_socket(
     Ok(Arc::new(UdpSocket::from_std(sock.into())?))
 }
 
-/// Create a UDP send socket for DHCPv4 replies (fallback when BPF is unavailable).
+/// Create a UDP send socket for DHCPv4 replies (FreeBSD BPF fallback only; other
+/// platforms reply directly from the per-worker receive socket).
+#[cfg(target_os = "freebsd")]
 fn build_udp_send_socket(
     bind_ip: Ipv4Addr,
     port: u16,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,22 @@
+use std::net::Ipv4Addr;
 #[cfg(target_os = "freebsd")]
 use std::os::unix::io::AsRawFd;
-use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 #[cfg(unix)]
 mod single_instance;
 
-use rdhcpd::{allocator, api, lease};
 use rdhcpd::api::ApiState;
 #[cfg(target_os = "freebsd")]
 use rdhcpd::bpf::BpfSender;
 use rdhcpd::config::Config;
 use rdhcpd::dhcpv4::server::{DhcpSender, DhcpV4Server};
-use rdhcpd::dhcpv6::server::{generate_server_duid, DhcpV6Server};
+use rdhcpd::dhcpv6::server::{DhcpV6Server, generate_server_duid};
 use rdhcpd::ha::StandaloneBackend;
 use rdhcpd::lease::store::LeaseStore;
 use rdhcpd::ratelimit::{GlobalRateLimiter, RateLimiter, RogueDetector};
 use rdhcpd::wal::Wal;
+use rdhcpd::{allocator, api, lease};
 use tokio::net::UdpSocket;
 use tracing::{error, info, warn};
 
@@ -83,11 +83,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ha: Arc<StandaloneBackend> = match &config.ha {
         rdhcpd::config::HaConfig::Standalone => Arc::new(StandaloneBackend),
         rdhcpd::config::HaConfig::ActiveActive { .. } => {
-            error!("active-active HA mode is not yet implemented — refusing to start in standalone silently");
+            error!(
+                "active-active HA mode is not yet implemented — refusing to start in standalone silently"
+            );
             std::process::exit(1);
         }
         rdhcpd::config::HaConfig::Raft { .. } => {
-            error!("raft HA mode is not yet implemented — refusing to start in standalone silently");
+            error!(
+                "raft HA mode is not yet implemented — refusing to start in standalone silently"
+            );
             std::process::exit(1);
         }
     };
@@ -140,7 +144,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Warn if API is bound to a non-loopback address without authentication
         if api_config.api_key.is_none() {
             let addr = &api_config.listen;
-            let is_loopback = addr.starts_with("127.") || addr.starts_with("localhost") || addr.starts_with("[::1]");
+            let is_loopback = addr.starts_with("127.")
+                || addr.starts_with("localhost")
+                || addr.starts_with("[::1]");
             if !is_loopback {
                 warn!(
                     listen = %addr,
@@ -172,11 +178,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server_ip = config
         .subnet
         .iter()
-        .find_map(|s| {
-            s.router
-                .as_ref()
-                .and_then(|r| r.parse::<Ipv4Addr>().ok())
-        })
+        .find_map(|s| s.router.as_ref().and_then(|r| r.parse::<Ipv4Addr>().ok()))
         .unwrap_or(Ipv4Addr::UNSPECIFIED);
 
     // Check if we have v4 subnets
@@ -201,7 +203,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(67);
     if dhcpv4_port != 67 {
-        warn!(port = dhcpv4_port, "RDHCPD_V4_PORT override active — not for production use");
+        warn!(
+            port = dhcpv4_port,
+            "RDHCPD_V4_PORT override active — not for production use"
+        );
     }
 
     // Start DHCPv4 server if v4 subnets configured
@@ -235,12 +240,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             for subnet in config.subnet.iter().filter(|s| s.network.contains('.')) {
                                 let cidr_parts: Vec<&str> = subnet.network.split('/').collect();
                                 if cidr_parts.len() == 2 {
-                                    if let (Ok(net_v4), Ok(prefix)) = (cidr_parts[0].parse::<Ipv4Addr>(), cidr_parts[1].parse::<u8>()) {
-                                        let mask = if prefix >= 32 { u32::MAX } else { u32::MAX << (32 - prefix) };
+                                    if let (Ok(net_v4), Ok(prefix)) = (
+                                        cidr_parts[0].parse::<Ipv4Addr>(),
+                                        cidr_parts[1].parse::<u8>(),
+                                    ) {
+                                        let mask = if prefix >= 32 {
+                                            u32::MAX
+                                        } else {
+                                            u32::MAX << (32 - prefix)
+                                        };
                                         if (u32::from(ip) & mask) == (u32::from(net_v4) & mask) {
-                                            let iface_name = unsafe { std::ffi::CStr::from_ptr(ifa.ifa_name) }
-                                                .to_string_lossy()
-                                                .into_owned();
+                                            let iface_name =
+                                                unsafe { std::ffi::CStr::from_ptr(ifa.ifa_name) }
+                                                    .to_string_lossy()
+                                                    .into_owned();
                                             info!(
                                                 interface = %iface_name,
                                                 ip = %ip,
@@ -272,18 +285,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let name = unsafe { std::ffi::CStr::from_ptr(ifa.ifa_name) }
                                     .to_string_lossy();
                                 if name == iface_name.as_str() {
-                                    let sdl = unsafe {
-                                        &*(ifa.ifa_addr as *const libc::sockaddr_dl)
-                                    };
+                                    let sdl =
+                                        unsafe { &*(ifa.ifa_addr as *const libc::sockaddr_dl) };
                                     if sdl.sdl_alen == 6 {
                                         let mac_ptr = unsafe {
-                                            (sdl as *const libc::sockaddr_dl as *const u8)
-                                                .add(sdl.sdl_nlen as usize
-                                                    + std::mem::offset_of!(libc::sockaddr_dl, sdl_data))
+                                            (sdl as *const libc::sockaddr_dl as *const u8).add(
+                                                sdl.sdl_nlen as usize
+                                                    + std::mem::offset_of!(
+                                                        libc::sockaddr_dl,
+                                                        sdl_data
+                                                    ),
+                                            )
                                         };
                                         let mut mac = [0u8; 6];
                                         unsafe {
-                                            std::ptr::copy_nonoverlapping(mac_ptr, mac.as_mut_ptr(), 6);
+                                            std::ptr::copy_nonoverlapping(
+                                                mac_ptr,
+                                                mac.as_mut_ptr(),
+                                                6,
+                                            );
                                         }
                                         info!(
                                             interface = %iface_name,
@@ -303,7 +323,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
 
-                unsafe { libc::freeifaddrs(ifaddrs_ptr); }
+                unsafe {
+                    libc::freeifaddrs(ifaddrs_ptr);
+                }
             }
         }
 
@@ -313,21 +335,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(target_os = "freebsd")]
         let sender: Arc<DhcpSender> = {
             match (&detected_iface, &detected_mac) {
-                (Some(iface), Some(mac)) => {
-                    match BpfSender::open(iface, *mac, send_bind_ip) {
-                        Ok(bpf) => {
-                            info!("using BPF raw-frame sender for DHCPv4 replies");
-                            Arc::new(DhcpSender::Bpf(Arc::new(bpf)))
-                        }
-                        Err(e) => {
-                            warn!(error = %e, "BPF open failed, falling back to UDP sender");
-                            Arc::new(DhcpSender::Udp(build_udp_send_socket(send_bind_ip, dhcpv4_port)?))
-                        }
+                (Some(iface), Some(mac)) => match BpfSender::open(iface, *mac, send_bind_ip) {
+                    Ok(bpf) => {
+                        info!("using BPF raw-frame sender for DHCPv4 replies");
+                        Arc::new(DhcpSender::Bpf(Arc::new(bpf)))
                     }
-                }
+                    Err(e) => {
+                        warn!(error = %e, "BPF open failed, falling back to UDP sender");
+                        Arc::new(DhcpSender::Udp(build_udp_send_socket(
+                            send_bind_ip,
+                            dhcpv4_port,
+                        )?))
+                    }
+                },
                 _ => {
                     warn!("could not detect interface/MAC, falling back to UDP sender");
-                    Arc::new(DhcpSender::Udp(build_udp_send_socket(send_bind_ip, dhcpv4_port)?))
+                    Arc::new(DhcpSender::Udp(build_udp_send_socket(
+                        send_bind_ip,
+                        dhcpv4_port,
+                    )?))
                 }
             }
         };
@@ -415,7 +441,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             sock.set_nonblocking(true)?;
             apply_recv_buffer(&sock, recv_buffer_bytes, "[::]:547");
             sock.bind(&"[::]:547".parse::<std::net::SocketAddr>().unwrap().into())
-                .map_err(|e| format!("failed to bind DHCPv6 port 547: {} (try running as root)", e))?;
+                .map_err(|e| {
+                    format!(
+                        "failed to bind DHCPv6 port 547: {} (try running as root)",
+                        e
+                    )
+                })?;
             let dhcpv6_socket = Arc::new(UdpSocket::from_std(sock.into())?);
 
             let dhcpv6_server = DhcpV6Server::new(
@@ -460,7 +491,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match Config::load(&reload_config_path) {
                 Ok(_new_config) => {
-                    info!("configuration validated successfully (hot reload not yet implemented — restart required to apply changes)");
+                    info!(
+                        "configuration validated successfully (hot reload not yet implemented — restart required to apply changes)"
+                    );
                 }
                 Err(e) => {
                     error!(error = %e, "configuration validation failed");
@@ -566,8 +599,12 @@ fn build_recv_socket(
     let addr: std::net::SocketAddr = bind_addr
         .parse()
         .map_err(|e| format!("invalid bind address {}: {}", bind_addr, e))?;
-    sock.bind(&addr.into())
-        .map_err(|e| format!("failed to bind DHCPv4 {}: {} (try running as root)", bind_addr, e))?;
+    sock.bind(&addr.into()).map_err(|e| {
+        format!(
+            "failed to bind DHCPv4 {}: {} (try running as root)",
+            bind_addr, e
+        )
+    })?;
     Ok(Arc::new(UdpSocket::from_std(sock.into())?))
 }
 

--- a/src/ratelimit.rs
+++ b/src/ratelimit.rs
@@ -1,8 +1,8 @@
 //! Per-client rate limiting, global rate limiting, MAC-based access control,
 //! and rogue client detection.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
@@ -92,12 +92,13 @@ impl RateLimiter {
         }
 
         // New client — allocate only on first sight
-        let mut entry = self.buckets.entry(client_id.to_vec()).or_insert_with(|| {
-            TokenBucket {
+        let mut entry = self
+            .buckets
+            .entry(client_id.to_vec())
+            .or_insert_with(|| TokenBucket {
                 tokens: self.max_tokens as f64,
                 last_refill: now,
-            }
-        });
+            });
 
         let bucket = entry.value_mut();
 

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -213,10 +213,7 @@ impl Wal {
         fs::rename(&tmp_path, &self.path).await?;
 
         // Reopen the writer pointing at the new file (append mode)
-        let new_file = OpenOptions::new()
-            .append(true)
-            .open(&self.path)
-            .await?;
+        let new_file = OpenOptions::new().append(true).open(&self.path).await?;
         *writer = BufWriter::new(new_file);
 
         Ok(count)
@@ -312,9 +309,7 @@ impl Wal {
         buf
     }
 
-    async fn read_entry(
-        reader: &mut BufReader<File>,
-    ) -> Result<Option<WalEntry>, WalError> {
+    async fn read_entry(reader: &mut BufReader<File>) -> Result<Option<WalEntry>, WalError> {
         // Read op byte
         let op_byte = match read_u8(reader).await {
             Ok(v) => v,
@@ -344,7 +339,7 @@ impl Wal {
                 return Err(WalError::Corrupt {
                     offset: 0,
                     reason: format!("invalid ip version: {}", ip_version),
-                })
+                });
             }
         };
 
@@ -418,7 +413,10 @@ impl Wal {
                 if cid_len > MAX_CLIENT_ID_LEN {
                     return Err(WalError::Corrupt {
                         offset: 0,
-                        reason: format!("client_id length {} exceeds max {}", cid_len, MAX_CLIENT_ID_LEN),
+                        reason: format!(
+                            "client_id length {} exceeds max {}",
+                            cid_len, MAX_CLIENT_ID_LEN
+                        ),
                     });
                 }
                 let client_id = if cid_len > 0 {
@@ -437,7 +435,10 @@ impl Wal {
                 if hostname_len > MAX_HOSTNAME_LEN {
                     return Err(WalError::Corrupt {
                         offset: 0,
-                        reason: format!("hostname length {} exceeds max {}", hostname_len, MAX_HOSTNAME_LEN),
+                        reason: format!(
+                            "hostname length {} exceeds max {}",
+                            hostname_len, MAX_HOSTNAME_LEN
+                        ),
                     });
                 }
                 let hostname = if hostname_len > 0 {
@@ -478,7 +479,10 @@ impl Wal {
                 if subnet_len > MAX_SUBNET_LEN {
                     return Err(WalError::Corrupt {
                         offset: 0,
-                        reason: format!("subnet length {} exceeds max {}", subnet_len, MAX_SUBNET_LEN),
+                        reason: format!(
+                            "subnet length {} exceeds max {}",
+                            subnet_len, MAX_SUBNET_LEN
+                        ),
                     });
                 }
                 let mut subnet_buf = vec![0u8; subnet_len];

--- a/tests/dhcpv4_cross_subnet_migration.rs
+++ b/tests/dhcpv4_cross_subnet_migration.rs
@@ -73,6 +73,7 @@ fn make_global() -> GlobalConfig {
         accept_relayed: true,
         relay_rate_limit_burst: 100,
         relay_rate_limit_pps: 100.0,
+        recv_buffer_bytes: 0,
     }
 }
 

--- a/tests/dhcpv4_lease_stickiness.rs
+++ b/tests/dhcpv4_lease_stickiness.rs
@@ -84,6 +84,7 @@ fn make_global() -> GlobalConfig {
         accept_relayed: true,
         relay_rate_limit_burst: 100,
         relay_rate_limit_pps: 100.0,
+        recv_buffer_bytes: 0,
     }
 }
 

--- a/tests/dhcpv4_lease_stickiness.rs
+++ b/tests/dhcpv4_lease_stickiness.rs
@@ -12,7 +12,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use rdhcpd::allocator::{build_allocators, SubnetAllocator};
+use rdhcpd::allocator::{SubnetAllocator, build_allocators};
 use rdhcpd::config::{Config, GlobalConfig, HaConfig, SubnetConfig};
 use rdhcpd::dhcpv4::options::{DhcpOption, MessageType};
 use rdhcpd::dhcpv4::packet::DhcpV4Packet;
@@ -164,9 +164,10 @@ fn seed_lease(
         subnet: Arc::from(subnet),
     };
     if matches!(state, LeaseState::Offered | LeaseState::Bound)
-        && let Some(alloc) = allocators.get(subnet) {
-            alloc.allocate_specific(&IpAddr::V4(ip));
-        }
+        && let Some(alloc) = allocators.get(subnet)
+    {
+        alloc.allocate_specific(&IpAddr::V4(ip));
+    }
     lease_store.upsert(lease);
 }
 

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -79,6 +79,7 @@ fn make_global(accept_relayed: bool) -> GlobalConfig {
         accept_relayed,
         relay_rate_limit_burst: 100,
         relay_rate_limit_pps: 100.0,
+        recv_buffer_bytes: 0,
     }
 }
 

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -93,9 +93,7 @@ fn make_config(accept_relayed: bool, subnet: SubnetConfig) -> Config {
     }
 }
 
-async fn make_server(
-    cfg: Config,
-) -> (DhcpV4Server<StandaloneBackend>, Arc<DhcpV4Stats>) {
+async fn make_server(cfg: Config) -> (DhcpV4Server<StandaloneBackend>, Arc<DhcpV4Stats>) {
     let dir = tempdir_path();
     let lease_store = LeaseStore::new();
     let allocators = Arc::new(build_allocators(&cfg, &lease_store).unwrap());
@@ -254,7 +252,12 @@ async fn untrusted_relay_source_is_dropped_when_whitelist_populated() {
     assert_eq!(decision, RelayDecision::DroppedUntrustedRelay);
     use std::sync::atomic::Ordering;
     assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
-    assert_eq!(stats.relayed_dropped_untrusted_relay.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        stats
+            .relayed_dropped_untrusted_relay
+            .load(Ordering::Relaxed),
+        1
+    );
 }
 
 /// Source IP in trusted_relays → Accept.
@@ -275,7 +278,12 @@ async fn trusted_relay_source_is_accepted() {
     assert_eq!(decision, RelayDecision::Accept);
     use std::sync::atomic::Ordering;
     assert_eq!(stats.relayed_received.load(Ordering::Relaxed), 1);
-    assert_eq!(stats.relayed_dropped_untrusted_relay.load(Ordering::Relaxed), 0);
+    assert_eq!(
+        stats
+            .relayed_dropped_untrusted_relay
+            .load(Ordering::Relaxed),
+        0
+    );
 }
 
 /// Empty trusted_relays list → any relay source is accepted.
@@ -306,12 +314,15 @@ async fn relayed_packets_are_rate_limited_per_source() {
     let relay_src = src_addr(Ipv4Addr::new(10, 0, 0, 5));
 
     // First packet: consumes the single token → accepted
-    assert_eq!(server.classify_relayed(&pkt, relay_src), RelayDecision::Accept);
-    // Second packet: limiter empty → rate-limit drop
-    assert_eq!(server.classify_relayed(&pkt, relay_src), RelayDecision::DroppedRateLimit);
-    use std::sync::atomic::Ordering;
     assert_eq!(
-        stats.relayed_dropped_rate_limit.load(Ordering::Relaxed),
-        1
+        server.classify_relayed(&pkt, relay_src),
+        RelayDecision::Accept
     );
+    // Second packet: limiter empty → rate-limit drop
+    assert_eq!(
+        server.classify_relayed(&pkt, relay_src),
+        RelayDecision::DroppedRateLimit
+    );
+    use std::sync::atomic::Ordering;
+    assert_eq!(stats.relayed_dropped_rate_limit.load(Ordering::Relaxed), 1);
 }


### PR DESCRIPTION
## Summary

Three related changes, batched as v0.15.0:

1. **Dependency refresh** — `cargo update`/`upgrade` bump in `Cargo.lock`. Full test suite passes; no code changes required.

2. **New `recv_buffer_bytes` option (`SO_RCVBUF`)** — global config, default 4 MiB, applied to the DHCPv4 and DHCPv6 receive sockets. Boot storms (many clients powering on at once) now queue in the kernel instead of overflowing the ~208 KB default socket buffer and dropping requests. The server logs the granted size on startup and warns when the kernel caps it below the request (raise `net.core.rmem_max` to grant more).

3. **Fix: DHCPv4 send-socket reuseport bug** — on non-FreeBSD, rDHCP created a separate send socket bound to `0.0.0.0:67` with `SO_REUSEPORT`, which enrolled it in the *receive* reuseport group. The kernel's flow hash could then steer inbound broadcast DHCP requests to that send socket — which the server never reads — silently dropping them. Which socket won the hash was non-deterministic per boot, so a broadcast-only deployment could intermittently fail to answer clients. Replies now come from each worker's own receive socket (correct source port 67, broadcast-capable). FreeBSD keeps its BPF/UDP sender.

## Verification

- `cargo clippy --all-targets` clean; **83 tests pass**; release build OK.
- Reuseport fix: one socket on `:67` now (was two); 5/5 fresh-namespace load runs process 5000/5000 deterministically (previously flip-flopped between full and zero).
- Buffer: at a fixed overload, raising `recv_buffer_bytes` 128 KB → 32 MB took processed from 34.6k → 101.5k and receive-buffer drops from 117k → 29k.

## Notes

- FreeBSD's reply path is unchanged and `cfg`-gated, but was not compile-tested in this environment.
