### PR TITLE
chore(bench): sample RSS over time as a leak-regression guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rdhcpd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -456,6 +456,11 @@ sudo apt install kea-admin
 sudo ./bench/run.sh
 ```
 
+Each test samples the server's RSS once per second during the load and prints a
+`start / peak / end / drift` line alongside throughput. A large positive drift under
+a bounded workload (e.g. the renewal storm, where the client set is fixed) is a
+memory-leak signal — it should stay near zero.
+
 ## Configuration Reference
 
 ### `[global]`

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -17,6 +17,29 @@ NC='\033[0m'
 header() { echo -e "\n${BOLD}${CYAN}$1${NC}\n"; }
 label()  { echo -e "${BOLD}$1${NC}"; }
 
+# ─── Memory sampling (leak-regression guard) ─────────────────────────
+# Sample a process's RSS (KB) once per second to a file until it exits.
+# Run in the background during a load test, then summarize the trajectory.
+sample_mem() { # pid outfile
+    local pid="$1" out="$2"
+    : > "$out"
+    while kill -0 "$pid" 2>/dev/null; do
+        echo "$(date +%s) $(ps -o rss= -p "$pid" 2>/dev/null | tr -d ' ')" >> "$out"
+        sleep 1
+    done
+}
+
+# Print start / peak / end / drift for a sampled RSS trajectory. A large positive
+# drift under a bounded (renewal / fixed-client) workload signals a possible leak.
+mem_summary() { # outfile
+    awk '
+        $2!=""{ if(n==0)s=$2; e=$2; if($2>mx)mx=$2; n++ }
+        END{
+            if(n==0){ printf "    mem: (no samples)\n"; exit }
+            printf "    mem: start=%dKB  peak=%dKB  end=%dKB  drift=%+dKB  over %ds\n", s, mx, e, e-s, n-1
+        }' "$1"
+}
+
 kill_dhcp() {
     sudo pkill -f "rdhcpd.*bench" 2>/dev/null || true
     sudo pkill -f "kea-dhcp4.*bench" 2>/dev/null || true
@@ -61,12 +84,16 @@ run_test() {
     fi
 
     echo -e "  ${GREEN}rDHCP:${NC}"
+    sample_mem "$RDHCP_PID" /tmp/rdhcpd-bench/mem.dat &
+    local RDHCP_SAMPLER=$!
     sudo perfdhcp -4 -r "$rate" -n "$count" -R "$clients" -l lo 10.0.0.1 2>&1 | \
         grep -E "sent|received|drops|min|avg|max|Rate" | sed 's/^/    /' || true
+    kill "$RDHCP_SAMPLER" 2>/dev/null; wait "$RDHCP_SAMPLER" 2>/dev/null || true
 
-    # Get memory usage
+    # Memory: final snapshot + trajectory over the load (leak-regression guard)
     RDHCP_RSS=$(ps -o rss= -p $RDHCP_PID 2>/dev/null | tr -d ' ')
-    echo "    RSS: ${RDHCP_RSS:-?} KB"
+    echo "    RSS (final): ${RDHCP_RSS:-?} KB"
+    mem_summary /tmp/rdhcpd-bench/mem.dat
 
     sudo kill $RDHCP_PID 2>/dev/null; wait $RDHCP_PID 2>/dev/null || true
     sleep 0.5
@@ -83,12 +110,16 @@ run_test() {
     fi
 
     echo -e "  ${RED}Kea:${NC}"
+    sample_mem "$KEA_PID" /tmp/kea-bench/mem.dat &
+    local KEA_SAMPLER=$!
     sudo perfdhcp -4 -r "$rate" -n "$count" -R "$clients" -l lo 10.0.0.1 2>&1 | \
         grep -E "sent|received|drops|min|avg|max|Rate" | sed 's/^/    /' || true
+    kill "$KEA_SAMPLER" 2>/dev/null; wait "$KEA_SAMPLER" 2>/dev/null || true
 
-    # Get memory usage
+    # Memory: final snapshot + trajectory over the load
     KEA_RSS=$(ps -o rss= -p $KEA_PID 2>/dev/null | tr -d ' ')
-    echo "    RSS: ${KEA_RSS:-?} KB"
+    echo "    RSS (final): ${KEA_RSS:-?} KB"
+    mem_summary /tmp/kea-bench/mem.dat
 
     sudo kill $KEA_PID 2>/dev/null; wait $KEA_PID 2>/dev/null || true
     sleep 0.5


### PR DESCRIPTION
## Summary

The benchmark harness previously captured a single RSS snapshot at the end of each test. It now **samples the server's RSS once per second during the load** and prints a `start / peak / end / drift` line for both rDHCP and Kea.

This turns `bench/run.sh` into a lightweight memory-leak regression guard: under a **bounded** workload (e.g. the renewal storm, where the client set is fixed), `drift` should stay near zero — a large positive drift flags a possible leak.

## Changes
- `bench/run.sh`: `sample_mem` + `mem_summary` helpers; wired into both server sections.
- `README.md`: note the new memory-trajectory output in the Benchmarking section.
- Version bump `0.15.0 -> 0.15.1`.

## Context

Follow-up to leak testing on v0.15.0. Findings so far: **no hot-path leak** (bounded 500-client workload held RSS perfectly flat over ~1.2M packets); under *unique*-client churn RSS grows but the per-client rate-limiter/rogue maps are hard-capped at 100k entries and lease expiry reclaims correctly, so growth is bounded by design. This harness change makes that trajectory visible on every run.